### PR TITLE
chore(release): fix github actions

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,5 +3,6 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "access": "public"
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,5 +64,7 @@ jobs:
 
       - name: Run Changeset
         uses: changesets/action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           publish: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
 
 jobs:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,12 +8,9 @@ This project uses [Changesets](https://github.com/changesets/changesets) to auto
 
 1. When making changes that affect the public API or behavior, **create a changeset**.
 2. Merging PRs with changesets will prompt the CI to open a **Version Packages PR**.
-3. Merging the Version Packages PR:
-   - Bumps `package.json` versions
-   - Updates the changelog
-   - Triggers an automatic release to npm
+3. Merging the Version Packages PR finalizes versioning and changelogs. To publish, create a git tag like `v0.1.0` and push it to trigger the release workflow.
 
-No tags, no manual version bumps, no manual publishing — it's all handled for you.
+No manual version bumps or changelog edits — Changesets handles those. Publishing is triggered by pushing a version tag.
 
 ---
 
@@ -24,3 +21,18 @@ Before merging a PR with public changes (new features, fixes, etc.), run:
 ```bash
 npm run changeset
 ```
+
+---
+
+## 🚀 Triggering the Release
+
+Before creating a git tag, verify that the version you want to release matches the version declared in `package.json`.
+
+After merging the Version Packages PR to `main`, you can publish a new release by creating and pushing a git tag:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+Replace `v0.1.0` with the desired version. This version should match the version in `package.json`. This will trigger the release workflow and publish the package.


### PR DESCRIPTION
Fixes for the GitHub Actions and an important change to only trigger releases on tags with the format 'vx.x.x'.