### PR TITLE
feat(prefixedLogger): withPrefix

### DIFF
--- a/.changeset/shaky-otters-wave.md
+++ b/.changeset/shaky-otters-wave.md
@@ -1,0 +1,5 @@
+---
+'emitnlog': minor
+---
+
+PrefixedLogger: use `withPrefix` to automatically add prefixes to log messages

--- a/README.md
+++ b/README.md
@@ -128,6 +128,35 @@ logger.error('Something went wrong', error);
 logger.debug(() => `Expensive operation result: ${computeExpensiveValue()}`);
 ```
 
+### Prefixed Logger
+
+Categorize and organize your logs by adding fixed prefixes:
+
+```ts
+import { ConsoleLogger, withPrefix } from 'emitnlog/logger';
+
+const logger = new ConsoleLogger();
+
+// Create a prefixed logger for a component
+const dbLogger = withPrefix(logger, 'DB: ');
+dbLogger.i`Connected to database`; // Logs: "DB: Connected to database"
+
+// Create a more specific logger with nested prefixes
+const userDbLogger = withPrefix(dbLogger, 'users/');
+userDbLogger.w`User not found: ${userId}`; // Logs: "DB: users/User not found: 123"
+
+// Hover over these in your IDE to see their full prefixes!
+// Type of dbLogger: PrefixedLogger<'DB: '>
+// Type of userDbLogger: PrefixedLogger<'DB: users/'>
+
+// Errors maintain their original objects
+const error = new Error('Connection failed');
+dbLogger.error(error); // Logs the prefixed message while preserving the error object
+
+// Works with all log levels and methods
+dbLogger.d`Query executed in ${queryTime}ms`;
+```
+
 ### File Logging (Node.js only)
 
 For persistent logging in Node.js environments:

--- a/README.md
+++ b/README.md
@@ -5,30 +5,30 @@
 [![CI](https://github.com/m-paternostro/emitnlog/actions/workflows/ci.yaml/badge.svg)](https://github.com/m-paternostro/emitnlog/actions/workflows/ci.yaml)
 [![Coverage](https://m-paternostro.github.io/emitnlog/coverage/coverage-badge.svg)](https://m-paternostro.github.io/emitnlog/coverage/)
 
-# 🚦 Emit n' Log
+# Emit n' Log
 
 A modern, type-safe library for logging and event notifications in JavaScript/TypeScript apps.
 
 Practical utilities for modern TypeScript projects:
 
-- 🧪 Clear logs with structured data and lazy evaluation
-- 🧩 Lightweight observables without full-blown streams
-- 🛠 Zero dependencies
+- Clear logs with structured data and lazy evaluation
+- Lightweight observables without full-blown streams
+- Zero dependencies
 
 ---
 
-## 🗺 Table of Contents
+## Table of Contents
 
-- [Installation](#-installation)
-- [Features](#-features)
-- [Logger](#-logger)
-- [Event Notifier](#-event-notifier)
-- [Logger + Notifier Combined](#-logger--notifier-combined)
-- [Utilities](#-utilities)
+- [Installation](#installation)
+- [Features](#features)
+- [Logger](#logger)
+- [Event Notifier](#event-notifier)
+- [Logger + Notifier Combined](#logger--notifier-combined)
+- [Utilities](#utilities)
 
 ---
 
-## 🛠 Installation
+## Installation
 
 ```bash
 npm install emitnlog
@@ -36,17 +36,17 @@ npm install emitnlog
 
 ---
 
-## ✨ Features
+## Features
 
-- 📢 **Flexible Logger** with 9 severity levels and template literal magic
-- 🔔 **Type-safe Event Notifier** to broadcast events only when someone's listening
-- 🧵 **Lazy Evaluation** – compute messages and events only when needed
-- 💾 **Multiple Logger Targets** – console, stderr, file, or no-op
-- 📦 **Tiny Footprint** – no runtime bloat
+- **Flexible Logger** with 9 severity levels and template literal magic
+- **Type-safe Event Notifier** to broadcast events only when someone's listening
+- **Lazy Evaluation** – compute messages and events only when needed
+- **Multiple Logger Targets** – console, stderr, file, or no-op
+- **Tiny Footprint** – no runtime bloat
 
 ---
 
-## 📋 Logger
+## Logger
 
 A powerful logger inspired by [RFC5424](https://datatracker.ietf.org/doc/html/rfc5424), supporting both template-literal and traditional logging.
 
@@ -230,7 +230,7 @@ class MyCustomLogger extends BaseLogger {
 
 ---
 
-## 🔔 Event Notifier
+## Event Notifier
 
 A simple way to implement observable patterns. Listeners only get notified when something happens — and only if they're subscribed.
 
@@ -277,7 +277,7 @@ subscription.close();
 
 ---
 
-## 🧩 Logger + Notifier Combined
+## Logger + Notifier Combined
 
 Here's an example that uses both the logger and the event notifier:
 
@@ -321,7 +321,7 @@ uploader.upload('video.mp4');
 subscription.close();
 ```
 
-## 🔧 Utilities
+## Utilities
 
 A set of helpful utilities used internally but also available for direct use:
 
@@ -478,12 +478,12 @@ Polling stops automatically on timeout or interrupt. Call `close()` to stop earl
 
 ---
 
-## 📘 API Docs
+## API Docs
 
 See source JSDoc for full types and examples.
 
 ---
 
-## 📄 License
+## License
 
 MIT

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -2,6 +2,8 @@ export * from './base-logger.ts';
 export * from './console-error-logger.ts';
 export * from './console-logger.ts';
 export * from './formatter.ts';
+export * from './level-utils.ts';
 export * from './logger.ts';
 export * from './off-logger.ts';
+export * from './prefixed-logger.ts';
 export * from './tee-logger.ts';

--- a/src/logger/level-utils.ts
+++ b/src/logger/level-utils.ts
@@ -1,0 +1,98 @@
+import { exhaustiveCheck } from '../utils/common/exhaustive-check.ts';
+import type { LogLevel } from './logger.ts';
+
+/**
+ * Converts a LogLevel to its corresponding numeric weight value for comparison operations.
+ *
+ * This function maps each log level to a numeric value according to its severity, with lower numbers representing
+ * higher severity (more important) levels:
+ *
+ * - Emergency: 0 (highest severity)
+ * - Alert: 1
+ * - Critical: 2
+ * - Error: 3
+ * - Warning: 4
+ * - Notice: 5
+ * - Info: 6
+ * - Debug: 7
+ * - Trace: 8 (lowest severity)
+ *
+ * @example
+ *
+ * ```ts
+ * const errorWeight = toLevelWeight('error'); // Returns 3
+ * const debugWeight = toLevelWeight('debug'); // Returns 7
+ *
+ * // Compare severity levels
+ * if (toLevelWeight('error') < toLevelWeight('debug')) {
+ *   // This condition is true (3 < 7), meaning 'error' is more severe than 'debug'
+ * }
+ * ```
+ *
+ * @param level The log level to convert to a numeric weight
+ * @returns The numeric weight corresponding to the specified log level
+ */
+export const toLevelWeight = (level: LogLevel): number => {
+  switch (level) {
+    case 'trace':
+      return 8;
+
+    case 'debug':
+      return 7;
+
+    case 'info':
+      return 6;
+
+    case 'notice':
+      return 5;
+
+    case 'warning':
+      return 4;
+
+    case 'error':
+      return 3;
+
+    case 'critical':
+      return 2;
+
+    case 'alert':
+      return 1;
+
+    case 'emergency':
+      return 0;
+
+    default:
+      exhaustiveCheck(level);
+      return 20;
+  }
+};
+
+/**
+ * Determines whether a log entry should be emitted based on the configured logger level and the entry's level.
+ *
+ * This function implements the severity filtering logic of the logger:
+ *
+ * - When the logger level is 'off', no entries will be emitted
+ * - Otherwise, entries are emitted when their level's severity is equal to or greater than the logger's level
+ *
+ * For example, if the logger's level is set to 'warning', entries with levels 'warning', 'error', 'critical', 'alert',
+ * and 'emergency' will be emitted, while entries with levels 'notice', 'info', 'debug', and 'trace' will be filtered
+ * out.
+ *
+ * @example
+ *
+ * ```ts
+ * // When logger level is 'warning'
+ * shouldEmitEntry('warning', 'error'); // Returns true (error entries are emitted)
+ * shouldEmitEntry('warning', 'info'); // Returns false (info entries are filtered out)
+ *
+ * // When logger is turned off
+ * shouldEmitEntry('off', 'emergency'); // Returns false (nothing is emitted)
+ * ```
+ *
+ * @param level The current configured level of the logger or 'off'
+ * @param entryLevel The severity level of the log entry to be evaluated
+ * @returns True if the entry should be emitted, false otherwise
+ */
+export const shouldEmitEntry = (level: LogLevel | 'off', entryLevel: LogLevel): boolean =>
+  level !== 'off' && toLevelWeight(entryLevel) <= toLevelWeight(level);

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -1,5 +1,5 @@
 /**
- * Inspired by RFC5424, with an additional 'trace' level for ultra-detailed logging.
+ * The possible levels for the Logger, inspired by RFC5424, with an additional 'trace' level for ultra-detailed logging.
  *
  * The severity levels are assumed to be numerically ascending from most important to least important.
  *
@@ -36,7 +36,7 @@ export type LogLevel = 'trace' | 'debug' | 'info' | 'notice' | 'warning' | 'erro
  * - Entries logged with debug(), info(), or notice() methods will be filtered out
  * - Entries logged with warning(), error(), critical(), alert(), or emergency() will be emitted
  */
-export type Logger = {
+export interface Logger {
   /**
    * The current minimum severity level of the logger.
    *
@@ -539,7 +539,7 @@ export type Logger = {
    * @param args Additional arguments to include in the log entry
    */
   readonly log: (level: LogLevel, message: LogMessage, ...args: unknown[]) => void;
-};
+}
 
 /**
  * Type representing the content of a log entry. Can be a primitive value or a function that returns a primitive value.

--- a/src/logger/off-logger.ts
+++ b/src/logger/off-logger.ts
@@ -14,23 +14,33 @@ export const OFF_LOGGER: Logger = {
   },
 
   args: () => OFF_LOGGER,
+
   trace: () => void {},
   t: () => void {},
+
   debug: () => void {},
   d: () => void {},
+
   info: () => void {},
   i: () => void {},
+
   notice: () => void {},
   n: () => void {},
+
   warning: () => void {},
   w: () => void {},
+
   error: () => void {},
   e: () => void {},
+
   critical: () => void {},
   c: () => void {},
+
   alert: () => void {},
   a: () => void {},
+
   emergency: () => void {},
   em: () => void {},
+
   log: () => void {},
 } as const;

--- a/src/logger/prefixed-logger.ts
+++ b/src/logger/prefixed-logger.ts
@@ -1,0 +1,206 @@
+import { shouldEmitEntry } from './level-utils.ts';
+import type { Logger, LogLevel, LogMessage } from './logger.ts';
+import { OFF_LOGGER } from './off-logger.ts';
+
+/**
+ * A specialized logger that prepends a fixed prefix to all log messages.
+ *
+ * The PrefixedLogger maintains all the functionality of a standard Logger while ensuring every log message is
+ * automatically prefixed, making it easier to:
+ *
+ * - Categorize logs by component, module, or subsystem
+ * - Distinguish logs from different parts of your application
+ * - Create hierarchical logging structures with nested prefixes
+ *
+ * The prefix is stored as a read-only property and is strongly typed, enabling type checking and autocompletion
+ * support.
+ */
+export interface PrefixedLogger<TPrefix extends string = string> extends Logger {
+  /**
+   * The fixed prefix that is automatically prepended to all log messages. This value is set when the logger is created
+   * and cannot be modified.
+   */
+  readonly prefix: TPrefix;
+}
+
+/**
+ * Creates a new logger that prepends a specified prefix to all log messages.
+ *
+ * This function wraps an existing logger and returns a new logger instance where all log messages are automatically
+ * prefixed. This is useful for categorizing logs or distinguishing between different components in your application.
+ *
+ * Performance optimizations:
+ *
+ * - If the prefix is an empty string, the original logger is returned unchanged
+ * - If the logger is the `OFF_LOGGER`, it's returned directly to avoid unnecessary processing
+ * - Log levels are checked before prefixing to avoid string processing when logs won't be emitted
+ *
+ * @example
+ *
+ * ```ts
+ * // Create a basic prefixed logger
+ * const dbLogger = withPrefix(logger, 'DB: ');
+ * dbLogger.info('Connected to database'); // Logs: "DB: Connected to database"
+ *
+ * // Prefix is maintained with template literals
+ * dbLogger.d`Query executed in ${queryTime}ms`; // Logs: "DB: Query executed in 42ms"
+ *
+ * // Create nested prefixes for hierarchical logging
+ * const userDbLogger = withPrefix(dbLogger, 'users/');
+ * userDbLogger.w`User not found: ${userId}`; // Logs: "DB: users/User not found: 123"
+ *
+ * // Errors maintain their original objects while prefixing the message
+ * const error = new Error('Connection failed');
+ * dbLogger.error(error); // Logs prefixed message but preserves error object in args
+ *
+ * // Use with conditional logging
+ * dbLogger.level = isProduction ? 'info' : 'debug';
+ * dbLogger.d`This is only logged in non-production`; // Only emitted when level is 'debug' or 'trace'
+ * ```
+ *
+ * **Tip:** When supported by your development environment, hovering over a prefixed logger variable (like `dbLogger` in
+ * the examples above) will show the prefix in the tooltip due to the type parameter, making it easier to identify which
+ * prefix is being used.
+ *
+ * @param logger The base logger to wrap with prefix functionality
+ * @param prefix The prefix to prepend to all log messages
+ * @returns A new logger with the specified prefix, or the original logger if prefix is empty.
+ */
+export const withPrefix = <TPrefix extends string>(
+  logger: Logger,
+  prefix: TPrefix,
+): TPrefix extends '' ? Logger : PrefixedLogger<TPrefix> => {
+  if (prefix === '') {
+    return logger as TPrefix extends '' ? Logger : PrefixedLogger<TPrefix>;
+  }
+
+  if (logger === OFF_LOGGER) {
+    return logger as TPrefix extends '' ? Logger : PrefixedLogger<TPrefix>;
+  }
+
+  const prefixedLogger: PrefixedLogger<TPrefix> = {
+    level: logger.level,
+    prefix,
+
+    args(...args: unknown[]) {
+      logger.args(...args);
+      return prefixedLogger;
+    },
+
+    trace(message: LogMessage, ...args: unknown[]) {
+      logger.trace(() => `${prefix}${toMessage(message)}`, ...args);
+    },
+
+    t(strings: TemplateStringsArray, ...values: unknown[]) {
+      if (shouldEmitEntry(logger.level, 'trace')) {
+        logger.t(prefixTemplateString(strings, prefix), ...values);
+      }
+    },
+
+    debug(message: LogMessage, ...args: unknown[]) {
+      logger.debug(() => `${prefix}${toMessage(message)}`, ...args);
+    },
+
+    d(strings: TemplateStringsArray, ...values: unknown[]) {
+      if (shouldEmitEntry(logger.level, 'debug')) {
+        logger.d(prefixTemplateString(strings, prefix), ...values);
+      }
+    },
+
+    info(message: LogMessage, ...args: unknown[]) {
+      logger.info(() => `${prefix}${toMessage(message)}`, ...args);
+    },
+
+    i(strings: TemplateStringsArray, ...values: unknown[]) {
+      if (shouldEmitEntry(logger.level, 'info')) {
+        logger.i(prefixTemplateString(strings, prefix), ...values);
+      }
+    },
+
+    notice(message: LogMessage, ...args: unknown[]) {
+      if (shouldEmitEntry(logger.level, 'notice')) {
+        logger.notice(() => `${prefix}${toMessage(message)}`, ...args);
+      }
+    },
+
+    n(strings: TemplateStringsArray, ...values: unknown[]) {
+      if (shouldEmitEntry(logger.level, 'notice')) {
+        logger.n(prefixTemplateString(strings, prefix), ...values);
+      }
+    },
+
+    warning(message: LogMessage, ...args: unknown[]) {
+      logger.warning(() => `${prefix}${toMessage(message)}`, ...args);
+    },
+
+    w(strings: TemplateStringsArray, ...values: unknown[]) {
+      if (shouldEmitEntry(logger.level, 'warning')) {
+        logger.w(prefixTemplateString(strings, prefix), ...values);
+      }
+    },
+
+    error(error: LogMessage | Error | { error: unknown }, ...args: unknown[]) {
+      if (shouldEmitEntry(logger.level, 'error')) {
+        if (error instanceof Error) {
+          logger.error(`${prefix}${error.message}`, error, ...args);
+        } else if (error && typeof error === 'object' && 'error' in error) {
+          logger.error(`${prefix}${String(error.error)}`, error, ...args);
+        } else {
+          logger.error(() => `${prefix}${toMessage(error as LogMessage)}`, ...args);
+        }
+      }
+    },
+
+    e(strings: TemplateStringsArray, ...values: unknown[]) {
+      if (shouldEmitEntry(logger.level, 'error')) {
+        logger.e(prefixTemplateString(strings, prefix), ...values);
+      }
+    },
+
+    critical(message: LogMessage, ...args: unknown[]) {
+      logger.critical(() => `${prefix}${toMessage(message)}`, ...args);
+    },
+
+    c(strings: TemplateStringsArray, ...values: unknown[]) {
+      if (shouldEmitEntry(logger.level, 'critical')) {
+        logger.c(prefixTemplateString(strings, prefix), ...values);
+      }
+    },
+
+    alert(message: LogMessage, ...args: unknown[]) {
+      logger.alert(() => `${prefix}${toMessage(message)}`, ...args);
+    },
+
+    a(strings: TemplateStringsArray, ...values: unknown[]) {
+      if (shouldEmitEntry(logger.level, 'alert')) {
+        logger.a(prefixTemplateString(strings, prefix), ...values);
+      }
+    },
+
+    emergency(message: LogMessage, ...args: unknown[]) {
+      logger.emergency(() => `${prefix}${toMessage(message)}`, ...args);
+    },
+
+    em(strings: TemplateStringsArray, ...values: unknown[]) {
+      if (shouldEmitEntry(logger.level, 'emergency')) {
+        logger.em(prefixTemplateString(strings, prefix), ...values);
+      }
+    },
+
+    log(level: LogLevel, message: LogMessage, ...args: unknown[]) {
+      logger.log(level, () => `${prefix}${toMessage(message)}`, ...args);
+    },
+  };
+
+  return prefixedLogger as TPrefix extends '' ? Logger : PrefixedLogger<TPrefix>;
+};
+
+const prefixTemplateString = (strings: TemplateStringsArray, prefix: string): TemplateStringsArray => {
+  const newStrings = Array.from(strings);
+  newStrings[0] = `${prefix}${newStrings[0]}`;
+  const prefixedStrings = Object.assign(newStrings, { raw: Array.from(strings.raw) });
+  prefixedStrings.raw[0] = `${prefix}${prefixedStrings.raw[0]}`;
+  return prefixedStrings as unknown as TemplateStringsArray;
+};
+
+const toMessage = (message: LogMessage) => (typeof message === 'function' ? message() : message);

--- a/tests/jester.setup.ts
+++ b/tests/jester.setup.ts
@@ -36,12 +36,12 @@ export type TestLogger = ReturnType<typeof createTestLogger>;
  *
  * @returns A logger that can be used to test log messages.
  */
-export const createTestLogger = (): jest.Mocked<Logger> => {
+export const createTestLogger = (level: LogLevel = 'debug'): jest.Mocked<Logger> => {
   const logger = new (class extends BaseLogger {
     protected emitLine(): void {
       return;
     }
-  })('debug');
+  })(level);
 
   jest.spyOn(logger, 'log');
   jest.spyOn(logger as unknown as { emitLine: jest.Mock }, 'emitLine');

--- a/tests/logger/base-logger.test.ts
+++ b/tests/logger/base-logger.test.ts
@@ -64,7 +64,7 @@ describe('emitnlog.logger.BaseLogger', () => {
     logger = new TestLogger('trace');
   });
 
-  describe('Console Logging', () => {
+  describe('Basic Logging', () => {
     test('should log trace messages', () => {
       logger.trace('trace message');
       expect(logger.emittedLines).toHaveLength(1);
@@ -241,6 +241,29 @@ describe('emitnlog.logger.BaseLogger', () => {
       const messageFunction = jest.fn(() => 'expensive message');
       logger.info(messageFunction);
       expect(messageFunction).toHaveBeenCalled();
+    });
+
+    test('should handle lazy message functions', () => {
+      logger.level = 'info';
+
+      let count = 0;
+      const expensiveOperation = () => {
+        count++;
+        return 'result';
+      };
+
+      expect(logger.emittedLines).toEqual([]);
+      expect(count).toBe(0);
+      //
+      logger.info(() => `Computed: ${String(expensiveOperation())}`);
+      logger.debug(() => `Computed: ${String(expensiveOperation())}`);
+      logger.warning(() => `Computed: ${String(expensiveOperation())}`);
+      //
+      expect(logger.emittedLines[0].level).toBe('info');
+      expect(logger.emittedLines[0].message).toBe('Computed: result');
+      expect(logger.emittedLines[1].level).toBe('warning');
+      expect(logger.emittedLines[1].message).toBe('Computed: result');
+      expect(count).toBe(2);
     });
   });
 
@@ -456,6 +479,31 @@ describe('emitnlog.logger.BaseLogger', () => {
         expect(logger.emittedLines[7].level).toBe('emergency');
         expect(logger.emittedLines[7].message).toBe('Emergency with error: Test error');
       });
+    });
+
+    test('should handle lazy message stringification', () => {
+      logger.level = 'info';
+
+      let count = 0;
+      const expensiveStringification = {
+        toString() {
+          count++;
+          return 'result';
+        },
+      };
+
+      expect(logger.emittedLines).toEqual([]);
+      expect(count).toBe(0);
+      //
+      logger.i`Computed: ${expensiveStringification}`;
+      logger.d`Computed: ${expensiveStringification}`;
+      logger.w`Computed: ${expensiveStringification}`;
+      //
+      expect(logger.emittedLines[0].level).toBe('info');
+      expect(logger.emittedLines[0].message).toBe('Computed: result');
+      expect(logger.emittedLines[1].level).toBe('warning');
+      expect(logger.emittedLines[1].message).toBe('Computed: result');
+      expect(count).toBe(2);
     });
   });
 

--- a/tests/logger/formatter.test.ts
+++ b/tests/logger/formatter.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest, test } from '@jest/globals';
 
 import type { LogLevel } from '../../src/logger/index.ts';
 import { emitColorfulLine, emitLine } from '../../src/logger/index.ts';
@@ -36,31 +36,31 @@ describe('formatter', () => {
       expect(result).toContain(message);
     });
 
-    it('handles empty messages', () => {
+    test('handles empty messages', () => {
       const result = emitLine('info', '');
       expect(result).toMatch(/Sun Jan 01 2023.+\[info     \] /);
     });
 
-    it('handles messages with special characters', () => {
+    test('handles messages with special characters', () => {
       const result = emitLine('debug', 'Message with \n new line and "quotes"');
       expect(result).toContain('Message with \n new line and "quotes"');
       expect(result).toContain('[debug    ]');
     });
 
-    it('handles extremely long messages', () => {
+    test('handles extremely long messages', () => {
       const longMessage = 'a'.repeat(1000);
       const result = emitLine('info', longMessage);
       expect(result).toContain(longMessage);
       expect(result).toContain('[info     ]');
     });
 
-    it('handles messages with emoji', () => {
+    test('handles messages with emoji', () => {
       const message = '😀 Smiley face emoji message 🚀';
       const result = emitLine('info', message);
       expect(result).toContain(message);
     });
 
-    it('properly pads all log levels to 9 characters', () => {
+    test('properly pads all log levels to 9 characters', () => {
       const levels: LogLevel[] = [
         'trace',
         'debug',
@@ -106,33 +106,33 @@ describe('formatter', () => {
       expect(result).toContain(message);
     });
 
-    it('handles empty messages', () => {
+    test('handles empty messages', () => {
       const result = emitColorfulLine('info', '');
       expect(result).toContain('\x1b[2mSun Jan 01 2023');
       expect(result).toContain('\x1b[36m[info     ]\x1b[0m');
     });
 
-    it('handles messages with special characters', () => {
+    test('handles messages with special characters', () => {
       const result = emitColorfulLine('warning', 'Warning: \nMultiline\ntext with "quotes"');
       expect(result).toContain('Warning: \nMultiline\ntext with "quotes"');
       expect(result).toContain('\x1b[33m[warning  ]\x1b[0m');
     });
 
-    it('handles extremely long messages', () => {
+    test('handles extremely long messages', () => {
       const longMessage = 'a'.repeat(1000);
       const result = emitColorfulLine('error', longMessage);
       expect(result).toContain(longMessage);
       expect(result).toContain('\x1b[31m[error    ]\x1b[0m');
     });
 
-    it('handles messages with emoji', () => {
+    test('handles messages with emoji', () => {
       const message = '😀 Smiley face emoji message 🚀';
       const result = emitColorfulLine('info', message);
       expect(result).toContain(message);
       expect(result).toContain('\x1b[36m[info     ]\x1b[0m');
     });
 
-    it('properly applies ANSI escape sequences for different log levels', () => {
+    test('properly applies ANSI escape sequences for different log levels', () => {
       // Test trace (dim)
       expect(emitColorfulLine('trace', 'test')).toContain('\x1b[2m[trace    ]\x1b[0m');
 
@@ -147,7 +147,7 @@ describe('formatter', () => {
   describe('terminalFormatter', () => {
     // Using private methods indirectly through emitColorfulLine
 
-    it('applies dim formatting to timestamps in all log levels', () => {
+    test('applies dim formatting to timestamps in all log levels', () => {
       const levels: LogLevel[] = [
         'trace',
         'debug',
@@ -167,12 +167,12 @@ describe('formatter', () => {
       }
     });
 
-    it('preserves whitespace in formatted messages', () => {
+    test('preserves whitespace in formatted messages', () => {
       const result = emitColorfulLine('info', '  Indented message with    spaces  ');
       expect(result).toContain('  Indented message with    spaces  ');
     });
 
-    it('maintains ANSI color code structure with reset marker at the end', () => {
+    test('maintains ANSI color code structure with reset marker at the end', () => {
       // Check that all ANSI color codes end with reset marker \x1b[0m
       const result = emitColorfulLine('error', 'Error message');
 

--- a/tests/logger/level-utils.test.ts
+++ b/tests/logger/level-utils.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, test } from '@jest/globals';
+
+import type { LogLevel } from '../../src/logger/index.ts';
+import { shouldEmitEntry, toLevelWeight } from '../../src/logger/index.ts';
+
+describe('emitnlog.logger.level-utils', () => {
+  describe('toLevelWeight', () => {
+    test('should return 8 for trace level', () => {
+      expect(toLevelWeight('trace')).toBe(8);
+    });
+
+    test('should return 7 for debug level', () => {
+      expect(toLevelWeight('debug')).toBe(7);
+    });
+
+    test('should return 6 for info level', () => {
+      expect(toLevelWeight('info')).toBe(6);
+    });
+
+    test('should return 5 for notice level', () => {
+      expect(toLevelWeight('notice')).toBe(5);
+    });
+
+    test('should return 4 for warning level', () => {
+      expect(toLevelWeight('warning')).toBe(4);
+    });
+
+    test('should return 3 for error level', () => {
+      expect(toLevelWeight('error')).toBe(3);
+    });
+
+    test('should return 2 for critical level', () => {
+      expect(toLevelWeight('critical')).toBe(2);
+    });
+
+    test('should return 1 for alert level', () => {
+      expect(toLevelWeight('alert')).toBe(1);
+    });
+
+    test('should return 0 for emergency level', () => {
+      expect(toLevelWeight('emergency')).toBe(0);
+    });
+
+    test('should preserve the severity ordering', () => {
+      const levels: LogLevel[] = [
+        'emergency',
+        'alert',
+        'critical',
+        'error',
+        'warning',
+        'notice',
+        'info',
+        'debug',
+        'trace',
+      ];
+
+      // Verify that the weights are in ascending order
+      // (lower weight = higher severity)
+      for (let i = 0; i < levels.length - 1; i++) {
+        expect(toLevelWeight(levels[i])).toBeLessThan(toLevelWeight(levels[i + 1]));
+      }
+    });
+  });
+
+  describe('shouldEmitEntry', () => {
+    test('should return false when logger level is off', () => {
+      const loggerLevel = 'off';
+      const entryLevels: LogLevel[] = [
+        'emergency',
+        'alert',
+        'critical',
+        'error',
+        'warning',
+        'notice',
+        'info',
+        'debug',
+        'trace',
+      ];
+
+      entryLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(false);
+      });
+    });
+
+    test('when logger level is emergency, should only emit emergency entries', () => {
+      const loggerLevel: LogLevel = 'emergency';
+
+      expect(shouldEmitEntry(loggerLevel, 'emergency')).toBe(true);
+
+      const filteredLevels: LogLevel[] = ['alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug', 'trace'];
+
+      filteredLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(false);
+      });
+    });
+
+    test('when logger level is alert, should emit alert and emergency entries', () => {
+      const loggerLevel: LogLevel = 'alert';
+
+      const emittedLevels: LogLevel[] = ['alert', 'emergency'];
+      emittedLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(true);
+      });
+
+      const filteredLevels: LogLevel[] = ['critical', 'error', 'warning', 'notice', 'info', 'debug', 'trace'];
+
+      filteredLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(false);
+      });
+    });
+
+    test('when logger level is critical, should emit critical, alert, and emergency entries', () => {
+      const loggerLevel: LogLevel = 'critical';
+
+      const emittedLevels: LogLevel[] = ['critical', 'alert', 'emergency'];
+      emittedLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(true);
+      });
+
+      const filteredLevels: LogLevel[] = ['error', 'warning', 'notice', 'info', 'debug', 'trace'];
+
+      filteredLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(false);
+      });
+    });
+
+    test('when logger level is error, should emit error and higher severity entries', () => {
+      const loggerLevel: LogLevel = 'error';
+
+      const emittedLevels: LogLevel[] = ['error', 'critical', 'alert', 'emergency'];
+      emittedLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(true);
+      });
+
+      const filteredLevels: LogLevel[] = ['warning', 'notice', 'info', 'debug', 'trace'];
+
+      filteredLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(false);
+      });
+    });
+
+    test('when logger level is warning, should emit warning and higher severity entries', () => {
+      const loggerLevel: LogLevel = 'warning';
+
+      const emittedLevels: LogLevel[] = ['warning', 'error', 'critical', 'alert', 'emergency'];
+      emittedLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(true);
+      });
+
+      const filteredLevels: LogLevel[] = ['notice', 'info', 'debug', 'trace'];
+
+      filteredLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(false);
+      });
+    });
+
+    test('when logger level is notice, should emit notice and higher severity entries', () => {
+      const loggerLevel: LogLevel = 'notice';
+
+      const emittedLevels: LogLevel[] = ['notice', 'warning', 'error', 'critical', 'alert', 'emergency'];
+      emittedLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(true);
+      });
+
+      const filteredLevels: LogLevel[] = ['info', 'debug', 'trace'];
+
+      filteredLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(false);
+      });
+    });
+
+    test('when logger level is info, should emit info and higher severity entries', () => {
+      const loggerLevel: LogLevel = 'info';
+
+      const emittedLevels: LogLevel[] = ['info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency'];
+      emittedLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(true);
+      });
+
+      const filteredLevels: LogLevel[] = ['debug', 'trace'];
+
+      filteredLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(false);
+      });
+    });
+
+    test('when logger level is debug, should emit debug and higher severity entries', () => {
+      const loggerLevel: LogLevel = 'debug';
+
+      const emittedLevels: LogLevel[] = [
+        'debug',
+        'info',
+        'notice',
+        'warning',
+        'error',
+        'critical',
+        'alert',
+        'emergency',
+      ];
+      emittedLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(true);
+      });
+
+      const filteredLevels: LogLevel[] = ['trace'];
+
+      filteredLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(false);
+      });
+    });
+
+    test('when logger level is trace, should emit all entries', () => {
+      const loggerLevel: LogLevel = 'trace';
+
+      const emittedLevels: LogLevel[] = [
+        'trace',
+        'debug',
+        'info',
+        'notice',
+        'warning',
+        'error',
+        'critical',
+        'alert',
+        'emergency',
+      ];
+
+      emittedLevels.forEach((entryLevel) => {
+        expect(shouldEmitEntry(loggerLevel, entryLevel)).toBe(true);
+      });
+    });
+  });
+});

--- a/tests/logger/prefixed-logger.test.ts
+++ b/tests/logger/prefixed-logger.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+import type { Logger, LogLevel, PrefixedLogger } from '../../src/logger/index.ts';
+import { BaseLogger, OFF_LOGGER, shouldEmitEntry, withPrefix } from '../../src/logger/index.ts';
+import { createTestLogger } from '../jester.setup.ts';
+
+// Mock the shouldEmitEntry to track calls
+jest.mock('../../src/logger/level-utils.ts', () => ({
+  shouldEmitEntry: jest.fn().mockImplementation((level, messageLevel) => {
+    // Default implementation to allow testing level filtering
+    const levels = ['trace', 'debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency'];
+    const levelIndex = levels.indexOf(String(level));
+    const messageLevelIndex = levels.indexOf(String(messageLevel));
+    return levelIndex <= messageLevelIndex;
+  }),
+}));
+
+describe('emitnlog.logger.prefixed-logger', () => {
+  test('should return the original logger when prefix is empty', () => {
+    const logger = createTestLogger();
+    const prefixedLogger = withPrefix(logger, '');
+    expect(prefixedLogger).toBe(logger);
+  });
+
+  test('should return OFF_LOGGER when logger is OFF_LOGGER', () => {
+    const prefixedLogger = withPrefix(OFF_LOGGER, 'test: ');
+    expect(prefixedLogger).toBe(OFF_LOGGER);
+  });
+
+  test('should create a logger with prefix property', () => {
+    const logger = createTestLogger();
+    const prefixedLogger = withPrefix(logger, 'test: ');
+    expect(prefixedLogger.prefix).toBe('test: ');
+  });
+
+  test('should return the correct type', () => {
+    const logger = createTestLogger();
+
+    const emptyPrefix1: Logger = withPrefix(logger, '');
+    expect(emptyPrefix1).toBe(logger);
+
+    // @ts-expect-error - emptyPrefix2 is a Logger, not a PrefixedLogger<''>
+    const emptyPrefix2: PrefixedLogger<''> = withPrefix(logger, '');
+    expect(emptyPrefix2).toBe(logger);
+
+    const testPrefix1: PrefixedLogger<'test: '> = withPrefix(logger, 'test: ');
+    expect(testPrefix1).not.toBe(logger);
+
+    // @ts-expect-error - testPrefix2 is a PrefixedLogger<'test: '>, not a PrefixedLogger<'test'>
+    const testPrefix2: PrefixedLogger<'test'> = withPrefix(logger, 'test: ');
+    expect(testPrefix2).not.toBe(logger);
+  });
+
+  describe('logging methods', () => {
+    test('should prepend prefix to standard logging methods', () => {
+      const logger = createTestLogger();
+      const prefixedLogger = withPrefix(logger, 'test: ');
+
+      prefixedLogger.info('Hello, world!');
+      expect(logger).toHaveLoggedWith('info', 'test: Hello, world!');
+
+      prefixedLogger.debug('Debug message');
+      expect(logger).toHaveLoggedWith('debug', 'test: Debug message');
+
+      prefixedLogger.warning('Warning message');
+      expect(logger).toHaveLoggedWith('warning', 'test: Warning message');
+    });
+
+    test('should prepend prefix to template literal logging methods', () => {
+      const logger = createTestLogger();
+      const prefixedLogger = withPrefix(logger, 'test: ');
+
+      prefixedLogger.i`Value is ${42}`;
+      expect(logger).toHaveLoggedWith('info', 'test: Value is 42');
+
+      const testObj = { name: 'test' };
+      prefixedLogger.d`Objects: ${testObj}`;
+      expect(logger).not.toHaveLoggedWith('debug', 'test: Objects: [object Object]');
+    });
+
+    test('should handle lazy message functions when using basic methods', () => {
+      const emittedLines: string[] = [];
+      const logger = new (class extends BaseLogger {
+        protected emitLine(level: LogLevel, message: string): void {
+          emittedLines.push(`[${level}] ${message}`);
+        }
+      })();
+
+      const prefixedLogger = withPrefix(logger, 'test: ');
+
+      let count = 0;
+      const expensiveOperation = () => {
+        count++;
+        return 'result';
+      };
+
+      expect(emittedLines).toEqual([]);
+      expect(count).toBe(0);
+      //
+      prefixedLogger.info(() => `Computed: ${String(expensiveOperation())}`);
+      prefixedLogger.debug(() => `Computed: ${String(expensiveOperation())}`);
+      prefixedLogger.warning(() => `Computed: ${String(expensiveOperation())}`);
+      //
+      expect(emittedLines).toEqual(['[info] test: Computed: result', '[warning] test: Computed: result']);
+      expect(count).toBe(2);
+    });
+
+    test('should handle lazy message stringification when using template methods', () => {
+      const emittedLines: string[] = [];
+      const logger = new (class extends BaseLogger {
+        protected emitLine(level: LogLevel, message: string): void {
+          emittedLines.push(`[${level}] ${message}`);
+        }
+      })();
+
+      const prefixedLogger = withPrefix(logger, 'test: ');
+
+      let count = 0;
+      const expensiveStringification = {
+        toString() {
+          count++;
+          return 'result';
+        },
+      };
+
+      expect(emittedLines).toEqual([]);
+      expect(count).toBe(0);
+      //
+      prefixedLogger.i`Computed: ${expensiveStringification}`;
+      prefixedLogger.d`Computed: ${expensiveStringification}`;
+      prefixedLogger.w`Computed: ${expensiveStringification}`;
+      //
+      expect(emittedLines).toEqual(['[info] test: Computed: result', '[warning] test: Computed: result']);
+      expect(count).toBe(2);
+    });
+
+    test('should properly handle error objects', () => {
+      const logger = createTestLogger();
+      const prefixedLogger = withPrefix(logger, 'test: ');
+      const error = new Error('Something failed');
+
+      prefixedLogger.error(error);
+
+      // Should prefix the error message
+      expect(logger).toHaveLoggedWith('error', 'test: Something failed');
+
+      // The original error object should be passed as additional argument
+      const logCall = logger.log.mock.calls.find(([level]) => level === 'error');
+      expect(logCall?.[2]).toBe(error);
+    });
+
+    test('should properly handle error-like objects', () => {
+      const logger = createTestLogger();
+      const prefixedLogger = withPrefix(logger, 'test: ');
+      const errorObj = { error: 'Custom error data' };
+
+      prefixedLogger.error(errorObj);
+
+      // Should prefix the error message
+      expect(logger).toHaveLoggedWith('error', 'test: Custom error data');
+
+      // The original error object should be passed as additional argument
+      const logCall = logger.log.mock.calls.find(([level]) => level === 'error');
+      expect(logCall?.[2]).toBe(errorObj);
+    });
+  });
+
+  describe('level filtering', () => {
+    test('should check level before processing template literals', () => {
+      const logger = createTestLogger();
+      logger.level = 'info';
+      const prefixedLogger = withPrefix(logger, 'test: ');
+
+      // Reset the mock to clearly see if shouldEmitEntry is called
+      (shouldEmitEntry as jest.Mock).mockClear();
+
+      // This should be filtered out at the 'debug' level
+      prefixedLogger.d`Debug message`;
+
+      // Should check level before trying to process template
+      expect(shouldEmitEntry).toHaveBeenCalledWith('info', 'debug');
+
+      // The log method should not be called since level is above debug
+      expect(logger.log).not.toHaveBeenCalledWith('debug', expect.anything());
+    });
+
+    test('should respect logger level for standard methods', () => {
+      const logger = createTestLogger();
+      logger.level = 'warning';
+      const prefixedLogger = withPrefix(logger, 'test: ');
+
+      prefixedLogger.info('Info message');
+      prefixedLogger.debug('Debug message');
+      prefixedLogger.warning('Warning message');
+      prefixedLogger.error('Error message');
+
+      // Only warning and error should be logged
+      expect(logger.log).not.toHaveBeenCalledWith('info', expect.any(String));
+      expect(logger.log).not.toHaveBeenCalledWith('debug', expect.any(String));
+      expect(logger).toHaveLoggedWith('warning', 'test: Warning message');
+      expect(logger).toHaveLoggedWith('error', 'test: Error message');
+    });
+  });
+
+  describe('special cases', () => {
+    test('should allow chaining with args', () => {
+      const emittedLines: string[] = [];
+      const emittedArgs: (readonly unknown[])[] = [];
+      const logger = new (class extends BaseLogger {
+        protected emitLine(level: LogLevel, message: string, args: readonly unknown[]): void {
+          emittedLines.push(`[${level}] ${message}`);
+          emittedArgs.push(args);
+        }
+      })();
+
+      const prefixedLogger = withPrefix(logger, 'test: ');
+      prefixedLogger.args({ id: 123 }, 42).info('User logged in');
+      expect(emittedLines[0]).toBe('[info] test: User logged in');
+      expect(emittedArgs[0]).toEqual([{ id: 123 }, 42]);
+    });
+
+    test('should support nested prefixes', () => {
+      const baseLogger = createTestLogger();
+      const appLogger = withPrefix(baseLogger, 'app: ');
+      const userLogger = withPrefix(appLogger, 'user: ');
+
+      userLogger.info('Profile updated');
+
+      expect(baseLogger).toHaveLoggedWith('info', 'app: user: Profile updated');
+    });
+
+    test('should handle the log method with dynamic level', () => {
+      const logger = createTestLogger();
+      const prefixedLogger = withPrefix(logger, 'test: ');
+
+      prefixedLogger.log('notice', 'Important notice');
+
+      expect(logger).toHaveLoggedWith('notice', 'test: Important notice');
+    });
+  });
+
+  describe('all log levels', () => {
+    test('should prefix all log levels', () => {
+      const logger = createTestLogger();
+      const prefixedLogger = withPrefix(logger, 'test: ');
+
+      prefixedLogger.trace('Trace message');
+      prefixedLogger.debug('Debug message');
+      prefixedLogger.info('Info message');
+      prefixedLogger.notice('Notice message');
+      prefixedLogger.warning('Warning message');
+      prefixedLogger.error('Error message');
+      prefixedLogger.critical('Critical message');
+      prefixedLogger.alert('Alert message');
+      prefixedLogger.emergency('Emergency message');
+
+      expect(logger).toHaveLoggedWith('trace', 'test: Trace message');
+      expect(logger).toHaveLoggedWith('debug', 'test: Debug message');
+      expect(logger).toHaveLoggedWith('info', 'test: Info message');
+      expect(logger).toHaveLoggedWith('notice', 'test: Notice message');
+      expect(logger).toHaveLoggedWith('warning', 'test: Warning message');
+      expect(logger).toHaveLoggedWith('error', 'test: Error message');
+      expect(logger).toHaveLoggedWith('critical', 'test: Critical message');
+      expect(logger).toHaveLoggedWith('alert', 'test: Alert message');
+      expect(logger).toHaveLoggedWith('emergency', 'test: Emergency message');
+    });
+
+    test('should prefix all short-form template methods', () => {
+      const logger = createTestLogger('trace');
+      const prefixedLogger = withPrefix(logger, 'test: ');
+
+      prefixedLogger.t`Trace`;
+      prefixedLogger.d`Debug`;
+      prefixedLogger.i`Info`;
+      prefixedLogger.n`Notice`;
+      prefixedLogger.w`Warning`;
+      prefixedLogger.e`Error`;
+      prefixedLogger.c`Critical`;
+      prefixedLogger.a`Alert`;
+      prefixedLogger.em`Emergency`;
+
+      expect(logger).toHaveLoggedWith('trace', 'test: Trace');
+      expect(logger).toHaveLoggedWith('debug', 'test: Debug');
+      expect(logger).toHaveLoggedWith('info', 'test: Info');
+      expect(logger).toHaveLoggedWith('notice', 'test: Notice');
+      expect(logger).toHaveLoggedWith('warning', 'test: Warning');
+      expect(logger).toHaveLoggedWith('error', 'test: Error');
+      expect(logger).toHaveLoggedWith('critical', 'test: Critical');
+      expect(logger).toHaveLoggedWith('alert', 'test: Alert');
+      expect(logger).toHaveLoggedWith('emergency', 'test: Emergency');
+    });
+  });
+});

--- a/tests/logger/prefixed-logger.test.ts
+++ b/tests/logger/prefixed-logger.test.ts
@@ -42,13 +42,25 @@ describe('emitnlog.logger.prefixed-logger', () => {
     // @ts-expect-error - emptyPrefix2 is a Logger, not a PrefixedLogger<''>
     const emptyPrefix2: PrefixedLogger<''> = withPrefix(logger, '');
     expect(emptyPrefix2).toBe(logger);
+    expect(emptyPrefix2.prefix).toBeUndefined();
 
     const testPrefix1: PrefixedLogger<'test: '> = withPrefix(logger, 'test: ');
     expect(testPrefix1).not.toBe(logger);
+    expect(testPrefix1.prefix).toBe('test: ');
 
     // @ts-expect-error - testPrefix2 is a PrefixedLogger<'test: '>, not a PrefixedLogger<'test'>
     const testPrefix2: PrefixedLogger<'test'> = withPrefix(logger, 'test: ');
     expect(testPrefix2).not.toBe(logger);
+    expect(testPrefix2.prefix).toBe('test: ');
+
+    const combinedPrefix1: PrefixedLogger<'test: test2: '> = withPrefix(testPrefix1, 'test2: ');
+    expect(combinedPrefix1).not.toBe(testPrefix1);
+    expect(combinedPrefix1.prefix).toBe('test: test2: ');
+
+    // @ts-expect-error - combinedPrefix2 is a PrefixedLogger<'test: test2: '>, not a PrefixedLogger<'test2: '>
+    const combinedPrefix2: PrefixedLogger<'test2: '> = withPrefix(testPrefix1, 'test2: ');
+    expect(combinedPrefix2).not.toBe(combinedPrefix1);
+    expect(combinedPrefix2.prefix).toBe('test: test2: ');
   });
 
   describe('logging methods', () => {
@@ -221,8 +233,12 @@ describe('emitnlog.logger.prefixed-logger', () => {
 
     test('should support nested prefixes', () => {
       const baseLogger = createTestLogger();
-      const appLogger = withPrefix(baseLogger, 'app: ');
-      const userLogger = withPrefix(appLogger, 'user: ');
+
+      const appLogger: PrefixedLogger<'app: '> = withPrefix(baseLogger, 'app: ');
+      expect(appLogger.prefix).toBe('app: ');
+
+      const userLogger: PrefixedLogger<'app: user: '> = withPrefix(appLogger, 'user: ');
+      expect(userLogger.prefix).toBe('app: user: ');
 
       userLogger.info('Profile updated');
 

--- a/tests/logger/prefixed-logger.test.ts
+++ b/tests/logger/prefixed-logger.test.ts
@@ -117,6 +117,33 @@ describe('emitnlog.logger.prefixed-logger', () => {
       expect(count).toBe(2);
     });
 
+    test('should handle lazy message functions when using template methods', () => {
+      const emittedLines: string[] = [];
+      const logger = new (class extends BaseLogger {
+        protected emitLine(level: LogLevel, message: string): void {
+          emittedLines.push(`[${level}] ${message}`);
+        }
+      })();
+
+      const prefixedLogger = withPrefix(logger, 'test: ');
+
+      let count = 0;
+      const expensiveOperation = () => {
+        count++;
+        return 'result';
+      };
+
+      expect(emittedLines).toEqual([]);
+      expect(count).toBe(0);
+      //
+      prefixedLogger.i`Computed: ${expensiveOperation}`;
+      prefixedLogger.d`Computed: ${expensiveOperation}`;
+      prefixedLogger.w`Computed: ${expensiveOperation}`;
+      //
+      expect(emittedLines).toEqual(['[info] test: Computed: result', '[warning] test: Computed: result']);
+      expect(count).toBe(2);
+    });
+
     test('should handle lazy message stringification when using template methods', () => {
       const emittedLines: string[] = [];
       const logger = new (class extends BaseLogger {


### PR DESCRIPTION
The `withPrefix` makes it easier to use the logger in code that prefer using a well defined prefix for the emitted log entries.