### PR TITLE
feat(withPrefix): redesign after review

### DIFF
--- a/.changeset/sixty-facts-help.md
+++ b/.changeset/sixty-facts-help.md
@@ -1,0 +1,5 @@
+---
+'emitnlog': patch
+---
+
+PrefixedLogger improvements, including appendPrefix and resetPrefix utilities.

--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ const logger = new ConsoleLogger();
 const dbLogger = withPrefix(logger, 'DB');
 dbLogger.i`Connected to database`; // Logs: "DB: Connected to database"
 
-// Create a more specific logger with nested prefixes and message separator
-const userDbLogger = withPrefix(dbLogger, ':users', ' - ');
-userDbLogger.w`User not found: ${userId}`; // Logs: "DB:users - User not found: 123"
+// Create nested prefixes for hierarchical logging
+const userDbLogger = withPrefix(dbLogger, 'users');
+userDbLogger.w`User not found: ${userId}`; // Logs: "DB.users: User not found: 123"
 
 // Hover over these in your IDE to see their full prefixes!
 // Type of dbLogger: PrefixedLogger<'DB'>
-// Type of userDbLogger: PrefixedLogger<'DB:users'>
+// Type of userDbLogger: PrefixedLogger<'DB.users'>
 
 // Errors maintain their original objects
 const error = new Error('Connection failed');
@@ -149,6 +149,41 @@ dbLogger.error(error); // Logs the prefixed message while preserving the error o
 // Works with all log levels and methods
 dbLogger.d`Query executed in ${queryTime}ms`;
 ```
+
+#### Building Prefix Hierarchies
+
+For more complex applications, you can build sophisticated prefix hierarchies:
+
+```ts
+import { ConsoleLogger, withPrefix, appendPrefix, resetPrefix } from 'emitnlog/logger';
+
+const logger = new ConsoleLogger();
+
+// Start with a base logger
+const appLogger = withPrefix(logger, 'APP');
+const serviceLogger = appendPrefix(appLogger, 'UserService');
+const repoLogger = appendPrefix(serviceLogger, 'Repository');
+
+repoLogger.i`User data saved`; // Logs: "APP.UserService.Repository: User data saved"
+
+// Switch contexts while preserving the root logger
+const apiLogger = resetPrefix(repoLogger, 'API');
+const v1Logger = appendPrefix(apiLogger, 'v1');
+
+v1Logger.i`Request processed`; // Logs: "API.v1: Request processed"
+
+// Custom separators for different naming conventions
+const moduleLogger = withPrefix(logger, 'Auth', { prefixSeparator: '/', messageSeparator: ' >> ' });
+const tokenLogger = appendPrefix(moduleLogger, 'Token');
+
+tokenLogger.i`Token validated`; // Logs: "Auth/Token >> Token validated"
+```
+
+**Key Functions:**
+
+- `withPrefix(logger, prefix)` - Creates a new prefixed logger or extends an existing prefix chain
+- `appendPrefix(prefixedLogger, suffix)` - Utility to append a prefix to an existing prefixed logger
+- `resetPrefix(logger, newPrefix)` - Utility to replace any existing prefix with a completely new one
 
 ### File Logging (Node.js only)
 

--- a/src/logger/prefixed-logger.ts
+++ b/src/logger/prefixed-logger.ts
@@ -1,8 +1,11 @@
+import { isNotNullable } from '../utils/common/is-not-nullable.ts';
 import type { Logger, LogLevel, LogMessage } from './definition.ts';
 import { shouldEmitEntry } from './level-utils.ts';
 import { OFF_LOGGER } from './off-logger.ts';
 
 const prefixSymbol: unique symbol = Symbol('prefix');
+const separatorSymbol: unique symbol = Symbol('separator');
+const dataSymbol: unique symbol = Symbol('data');
 
 /**
  * A specialized logger that prepends a fixed prefix to all log messages.
@@ -16,14 +19,21 @@ const prefixSymbol: unique symbol = Symbol('prefix');
  *
  * The prefix is strongly typed and, in some development environments, is visible on the logger's tooltip.
  */
-export interface PrefixedLogger<TPrefix extends string> extends Logger {
+export interface PrefixedLogger<TPrefix extends string = string, TSeparator extends string = string> extends Logger {
   /*
-   * The prefix or, in some cases, undefined.
-   *
-   * This is an internal property, only exposed to ensure that the type system displays the prefix - moreover, due to
-   * performance reasons, sometimes is not set or even added to the object.
+   * The prefix or undefined.
    */
   readonly [prefixSymbol]: TPrefix | undefined;
+
+  /*
+   * The value used to separate different parts of the prefix, or undefined
+   */
+  readonly [separatorSymbol]: TSeparator | undefined;
+
+  /*
+   * Arbitrary data needed by the prefix logger.
+   */
+  readonly [dataSymbol]: { readonly rootLogger: Logger; readonly messageSeparator: string } | undefined;
 }
 
 /**
@@ -31,73 +41,162 @@ export interface PrefixedLogger<TPrefix extends string> extends Logger {
  *
  * This function wraps an existing logger and returns a new logger instance where all log messages are automatically
  * prefixed. This is useful for categorizing logs or distinguishing between different components in your application.
- * The log level of a prefixed logger is always the same of its "basic" logger.
+ * The log level of a prefixed logger is always the same as its underlying logger.
  *
  * When applied to an already prefixed logger, it preserves the full prefix chain both at runtime and in the type
  * system, allowing for strongly-typed nested prefixes.
  *
- * Performance optimizations:
- *
- * - If the prefix is an empty string, the original logger is returned unchanged
- * - If the logger is the `OFF_LOGGER`, it's returned directly to avoid unnecessary processing
- * - Log levels are checked before prefixing to avoid string processing when logs won't be emitted
- *
- * @example
+ * @example Basic Usage
  *
  * ```ts
- * // Create a basic prefixed logger using the default message separator `: `
+ * import { ConsoleLogger, withPrefix } from 'emitnlog/logger';
+ *
+ * const logger = new ConsoleLogger();
  * const dbLogger = withPrefix(logger, 'DB');
- * dbLogger.info('Connected to database'); // Logs: "DB: Connected to database"
+ *
+ * dbLogger.info('Connected to database');
+ * // Output: "DB: Connected to database"
+ * ```
+ *
+ * @example Template Literals
+ *
+ * ```ts
+ * const dbLogger = withPrefix(logger, 'DB');
+ * const queryTime = 42;
  *
  * // Prefix is maintained with template literals
- * dbLogger.d`Query executed in ${queryTime}ms`; // Logs: "DB: Query executed in 42ms"
+ * dbLogger.d`Query executed in ${queryTime}ms`;
+ * // Output: "DB: Query executed in 42ms"
+ * ```
  *
- * // Create nested prefixes for hierarchical logging maintaining the full prefix chain
- * // This is also setting a new message separator
- * const userDbLogger = withPrefix(dbLogger, '.users', ' - ');
+ * @example Nested Prefixes
+ *
+ * ```ts
+ * const dbLogger = withPrefix(logger, 'DB');
+ * const userDbLogger = withPrefix(dbLogger, 'users');
  * // Type of userDbLogger is PrefixedLogger<'DB.users'>
- * userDbLogger.w`User not found: ${userId}`; // Logs: "DB.users - User not found: 123"
+ *
+ * const userId = 123;
+ * userDbLogger.w`User not found: ${userId}`;
+ * // Output: "DB.users: User not found: 123"
+ * ```
+ *
+ * @example Error Handling
+ *
+ * ```ts
+ * const dbLogger = withPrefix(logger, 'DB');
  *
  * // Errors maintain their original objects while prefixing the message
  * const error = new Error('Connection failed');
- * dbLogger.error(error); // Logs the 'DB: ' prefixed message but preserves error object in args
+ * dbLogger.error(error);
+ * // Output: "DB: Connection failed" (with error object preserved in args)
  *
- * // Use with conditional logging
- * dbLogger.level = isProduction ? 'info' : 'debug';
- * dbLogger.d`This is only logged in non-production`; // Only emitted when level is 'debug' or 'trace'
+ * // Using args() for additional context
+ * dbLogger.args(error, { connectionId: 'conn_123' }).e`Database operation failed`;
  * ```
  *
- * **Tip:** When supported by your development environment, hovering over a prefixed logger variable (like `dbLogger` in
- * the examples above) shows the prefix in the tooltip due to the type parameter, making it easier to identify which
- * prefix is being used.
+ * @example Custom Separators
+ *
+ * ```ts
+ * // Custom prefix separator
+ * const apiLogger = withPrefix(logger, 'API', { prefixSeparator: '/' });
+ * const v1Logger = withPrefix(apiLogger, 'v1');
+ * v1Logger.info('Request processed');
+ * // Output: "API/v1: Request processed"
+ *
+ * // Custom message separator
+ * const compactLogger = withPrefix(logger, 'SYS', { messageSeparator: ' | ' });
+ * compactLogger.info('System ready');
+ * // Output: "SYS | System ready"
+ * ```
+ *
+ * @example Fallback Prefix
+ *
+ * ```ts
+ * // Add a fallback prefix when the logger isn't already prefixed
+ * const serviceLogger = withPrefix(logger, 'UserService', { fallbackPrefix: 'APP' });
+ * serviceLogger.info('Service started');
+ * // Output: "APP.UserService: Service started"
+ *
+ * // If applied to an already prefixed logger, fallback is ignored
+ * const dbLogger = withPrefix(logger, 'DB');
+ * const userDbLogger = withPrefix(dbLogger, 'UserService', {
+ *   fallbackPrefix: 'APP', // This is ignored
+ * });
+ * userDbLogger.info('Service started');
+ * // Output: "DB.UserService: Service started"
+ * ```
+ *
+ * @example Level Filtering
+ *
+ * ```ts
+ * const dbLogger = withPrefix(logger, 'DB');
+ *
+ * // Level filtering works the same as the underlying logger
+ * dbLogger.level = 'warning';
+ * dbLogger.d`This debug message won't be logged`;
+ * dbLogger.w`This warning will be logged`;
+ * // Output: "DB: This warning will be logged"
+ * ```
+ *
+ * **Tip:** When supported by your development environment, hovering over a prefixed logger variable shows the prefix in
+ * the tooltip due to the type parameter, making it easier to identify which prefix is being used.
  *
  * @param logger The base logger to wrap with prefix functionality
  * @param prefix The prefix to prepend to all log messages
- * @param messageSeparator The separator to use between the prefix and the log message. Defaults to `: `.
- * @returns A new logger with the specified prefix, or the original logger if the prefix is empty or if the logger is
- *   the `OFF_LOGGER`.
+ * @param options Optional configuration for the logger behavior
+ * @returns A new logger with the specified prefix, or the OFF_LOGGER if the input logger is OFF_LOGGER
  */
-export const withPrefix = <TLogger extends Logger, const TPrefix extends string>(
+export const withPrefix = <
+  TLogger extends Logger,
+  const TPrefix extends string,
+  const TSeparator extends string = '.',
+  const TFallbackPrefix extends string | undefined = undefined,
+>(
   logger: TLogger,
   prefix: TPrefix,
-  messageSeparator = ': ',
-): WithPrefixResult<TLogger, TPrefix> => {
-  if (prefix === '') {
-    return logger as unknown as WithPrefixResult<TLogger, TPrefix>;
-  }
+  options?: {
+    /**
+     * The separator to use between an existing prefix and the prefix passed to this method. Defaults to '.'.
+     */
+    readonly prefixSeparator?: TSeparator;
 
+    /**
+     * The separator to use between the prefix and the log message. Defaults to ': '.
+     */
+    readonly messageSeparator?: string;
+
+    /**
+     * The fallback prefix to use if the logger is not already a prefixed logger.
+     */
+    readonly fallbackPrefix?: TFallbackPrefix;
+  },
+): WithPrefixResult<TLogger, TPrefix, TSeparator, TFallbackPrefix> => {
   if (logger === OFF_LOGGER) {
-    return OFF_LOGGER as unknown as WithPrefixResult<TLogger, TPrefix>;
+    return OFF_LOGGER as unknown as WithPrefixResult<TLogger, TPrefix, TSeparator, TFallbackPrefix>;
   }
 
-  const data = toPrefixedLoggerData(logger);
+  let prefixSeparator: TSeparator;
+  let messageSeparator: string;
+
+  const data = inspectPrefixedLogger(logger);
   if (data) {
-    prefix = `${data.currentPrefix}${prefix}` as TPrefix;
-    logger = data.basicLogger as TLogger;
+    logger = data.rootLogger as TLogger;
+    prefixSeparator = data.separator as TSeparator;
+    messageSeparator = data.messageSeparator;
+    prefix = `${data.prefix}${prefixSeparator}${prefix}` as TPrefix;
+  } else {
+    prefixSeparator = (options?.prefixSeparator ?? '.') as TSeparator;
+    messageSeparator = options?.messageSeparator ?? ': ';
+    if (options?.fallbackPrefix) {
+      prefix = `${options.fallbackPrefix}${prefixSeparator}${prefix}` as TPrefix;
+    }
   }
 
-  const prefixedLogger: PrefixedLogger<TPrefix> = {
+  const prefixedLogger: PrefixedLogger<TPrefix, TSeparator> = {
     [prefixSymbol]: prefix,
+    [separatorSymbol]: prefixSeparator,
+    [dataSymbol]: { rootLogger: logger, messageSeparator },
 
     get level() {
       return logger.level;
@@ -113,137 +212,321 @@ export const withPrefix = <TLogger extends Logger, const TPrefix extends string>
     },
 
     trace(message: LogMessage, ...args: unknown[]) {
-      logger.trace(toMessageProvider(prefixedLogger, message, messageSeparator), ...args);
+      if (shouldEmitEntry(logger.level, 'trace')) {
+        logger.trace(toMessageProvider(prefixedLogger, message), ...args);
+      }
     },
 
     t(strings: TemplateStringsArray, ...values: unknown[]) {
       if (shouldEmitEntry(logger.level, 'trace')) {
-        logger.t(prefixTemplateString(prefixedLogger, strings, messageSeparator), ...values);
+        logger.t(prefixTemplateString(prefixedLogger, strings), ...values);
       }
     },
 
     debug(message: LogMessage, ...args: unknown[]) {
-      logger.debug(toMessageProvider(prefixedLogger, message, messageSeparator), ...args);
+      if (shouldEmitEntry(logger.level, 'debug')) {
+        logger.debug(toMessageProvider(prefixedLogger, message), ...args);
+      }
     },
 
     d(strings: TemplateStringsArray, ...values: unknown[]) {
       if (shouldEmitEntry(logger.level, 'debug')) {
-        logger.d(prefixTemplateString(prefixedLogger, strings, messageSeparator), ...values);
+        logger.d(prefixTemplateString(prefixedLogger, strings), ...values);
       }
     },
 
     info(message: LogMessage, ...args: unknown[]) {
-      logger.info(toMessageProvider(prefixedLogger, message, messageSeparator), ...args);
+      if (shouldEmitEntry(logger.level, 'info')) {
+        logger.info(toMessageProvider(prefixedLogger, message), ...args);
+      }
     },
 
     i(strings: TemplateStringsArray, ...values: unknown[]) {
       if (shouldEmitEntry(logger.level, 'info')) {
-        logger.i(prefixTemplateString(prefixedLogger, strings, messageSeparator), ...values);
+        logger.i(prefixTemplateString(prefixedLogger, strings), ...values);
       }
     },
 
     notice(message: LogMessage, ...args: unknown[]) {
       if (shouldEmitEntry(logger.level, 'notice')) {
-        logger.notice(toMessageProvider(prefixedLogger, message, messageSeparator), ...args);
+        logger.notice(toMessageProvider(prefixedLogger, message), ...args);
       }
     },
 
     n(strings: TemplateStringsArray, ...values: unknown[]) {
       if (shouldEmitEntry(logger.level, 'notice')) {
-        logger.n(prefixTemplateString(prefixedLogger, strings, messageSeparator), ...values);
+        logger.n(prefixTemplateString(prefixedLogger, strings), ...values);
       }
     },
 
     warning(message: LogMessage, ...args: unknown[]) {
-      logger.warning(toMessageProvider(prefixedLogger, message, messageSeparator), ...args);
+      if (shouldEmitEntry(logger.level, 'warning')) {
+        logger.warning(toMessageProvider(prefixedLogger, message), ...args);
+      }
     },
 
     w(strings: TemplateStringsArray, ...values: unknown[]) {
       if (shouldEmitEntry(logger.level, 'warning')) {
-        logger.w(prefixTemplateString(prefixedLogger, strings, messageSeparator), ...values);
+        logger.w(prefixTemplateString(prefixedLogger, strings), ...values);
       }
     },
 
     error(error: LogMessage | Error | { error: unknown }, ...args: unknown[]) {
       if (shouldEmitEntry(logger.level, 'error')) {
         if (error instanceof Error) {
-          logger.error(toMessageProvider(prefixedLogger, error.message, messageSeparator), error, ...args);
+          logger.error(toMessageProvider(prefixedLogger, error.message), error, ...args);
         } else if (error && typeof error === 'object' && 'error' in error) {
-          logger.error(toMessageProvider(prefixedLogger, String(error.error), messageSeparator), error, ...args);
+          logger.error(toMessageProvider(prefixedLogger, String(error.error)), error, ...args);
         } else {
-          logger.error(toMessageProvider(prefixedLogger, error as LogMessage, messageSeparator), ...args);
+          logger.error(toMessageProvider(prefixedLogger, error as LogMessage), ...args);
         }
       }
     },
 
     e(strings: TemplateStringsArray, ...values: unknown[]) {
       if (shouldEmitEntry(logger.level, 'error')) {
-        logger.e(prefixTemplateString(prefixedLogger, strings, messageSeparator), ...values);
+        logger.e(prefixTemplateString(prefixedLogger, strings), ...values);
       }
     },
 
     critical(message: LogMessage, ...args: unknown[]) {
-      logger.critical(toMessageProvider(prefixedLogger, message, messageSeparator), ...args);
+      if (shouldEmitEntry(logger.level, 'critical')) {
+        logger.critical(toMessageProvider(prefixedLogger, message), ...args);
+      }
     },
 
     c(strings: TemplateStringsArray, ...values: unknown[]) {
       if (shouldEmitEntry(logger.level, 'critical')) {
-        logger.c(prefixTemplateString(prefixedLogger, strings, messageSeparator), ...values);
+        logger.c(prefixTemplateString(prefixedLogger, strings), ...values);
       }
     },
 
     alert(message: LogMessage, ...args: unknown[]) {
-      logger.alert(toMessageProvider(prefixedLogger, message, messageSeparator), ...args);
+      if (shouldEmitEntry(logger.level, 'alert')) {
+        logger.alert(toMessageProvider(prefixedLogger, message), ...args);
+      }
     },
 
     a(strings: TemplateStringsArray, ...values: unknown[]) {
       if (shouldEmitEntry(logger.level, 'alert')) {
-        logger.a(prefixTemplateString(prefixedLogger, strings, messageSeparator), ...values);
+        logger.a(prefixTemplateString(prefixedLogger, strings), ...values);
       }
     },
 
     emergency(message: LogMessage, ...args: unknown[]) {
-      logger.emergency(toMessageProvider(prefixedLogger, message, messageSeparator), ...args);
+      if (shouldEmitEntry(logger.level, 'emergency')) {
+        logger.emergency(toMessageProvider(prefixedLogger, message), ...args);
+      }
     },
 
     em(strings: TemplateStringsArray, ...values: unknown[]) {
       if (shouldEmitEntry(logger.level, 'emergency')) {
-        logger.em(prefixTemplateString(prefixedLogger, strings, messageSeparator), ...values);
+        logger.em(prefixTemplateString(prefixedLogger, strings), ...values);
       }
     },
 
     log(level: LogLevel, message: LogMessage, ...args: unknown[]) {
-      logger.log(level, toMessageProvider(prefixedLogger, message, messageSeparator), ...args);
+      if (shouldEmitEntry(logger.level, level)) {
+        logger.log(level, toMessageProvider(prefixedLogger, message), ...args);
+      }
     },
   };
 
-  (prefixedLogger as unknown as { [basicLoggerSymbol]: Logger })[basicLoggerSymbol] = logger;
-  return prefixedLogger as WithPrefixResult<TLogger, TPrefix>;
+  return prefixedLogger as unknown as WithPrefixResult<TLogger, TPrefix, TSeparator, TFallbackPrefix>;
 };
 
-const basicLoggerSymbol: unique symbol = Symbol('basicLogger');
+/**
+ * Appends a prefix to an existing prefixed logger, creating a hierarchical prefix structure.
+ *
+ * This utility function is specifically designed for use with already prefixed loggers. It extends the existing prefix
+ * chain by appending a new prefix segment, using the same separator that was used in the original logger.
+ *
+ * Unlike `withPrefix`, this function has a simplified API that doesn't expose configuration options since it inherits
+ * all settings (separators, etc.) from the existing prefixed logger.
+ *
+ * @example Basic Appending
+ *
+ * ```ts
+ * import { consoleLogger, withPrefix, appendPrefix } from 'emitnlog/logger';
+ *
+ * const logger = new ConsoleLogger();
+ * const dbLogger = withPrefix(logger, 'DB');
+ * const userDbLogger = appendPrefix(dbLogger, 'users');
+ *
+ * userDbLogger.info('User created successfully');
+ * // Output: "DB.users: User created successfully"
+ * ```
+ *
+ * @example Multiple Levels of Nesting
+ *
+ * ```ts
+ * const serviceLogger = withPrefix(logger, 'UserService');
+ * const repositoryLogger = appendPrefix(serviceLogger, 'Repository');
+ * const cacheLogger = appendPrefix(repositoryLogger, 'Cache');
+ *
+ * cacheLogger.d`Cache hit for key: user_123`;
+ * // Output: "UserService.Repository.Cache: Cache hit for key: user_123"
+ * ```
+ *
+ * @example Preserving Custom Separators
+ *
+ * ```ts
+ * // Original logger with custom separator
+ * const apiLogger = withPrefix(logger, 'API', { prefixSeparator: '/' });
+ * const v1Logger = appendPrefix(apiLogger, 'v1');
+ * const usersLogger = appendPrefix(v1Logger, 'users');
+ *
+ * usersLogger.info('Processing user request');
+ * // Output: "API/v1/users: Processing user request"
+ * ```
+ *
+ * @example Type Safety
+ *
+ * ```ts
+ * const dbLogger = withPrefix(logger, 'DB');
+ * const userLogger = appendPrefix(dbLogger, 'User');
+ * // Type of userLogger is PrefixedLogger<'DB.User', '.'>
+ *
+ * // TypeScript knows the exact prefix structure
+ * const profileLogger = appendPrefix(userLogger, 'Profile');
+ * // Type of profileLogger is PrefixedLogger<'DB.User.Profile', '.'>
+ * ```
+ *
+ * @param logger The prefixed logger to append the prefix to
+ * @param prefix The prefix segment to append to the existing prefix chain
+ * @returns A new logger with the appended prefix, maintaining all original configuration
+ */
+export const appendPrefix = <
+  const TCurrentPrefix extends string,
+  const TSeparator extends string,
+  const TLogger extends PrefixedLogger<TCurrentPrefix, TSeparator>,
+  const TPrefix extends string,
+>(
+  logger: TLogger,
+  prefix: TPrefix,
+): WithPrefixResult<TLogger, TPrefix, TSeparator> => withPrefix(logger, prefix);
 
-const toPrefixedLoggerData = (
+/**
+ * Creates a prefixed logger with a completely new prefix, ignoring any existing prefix on the input logger.
+ *
+ * This utility function extracts the root (non-prefixed) logger from the input and applies a fresh prefix to it,
+ * effectively "resetting" the prefix chain. This is useful when you want to create a new prefix hierarchy without
+ * inheriting the existing prefix structure.
+ *
+ * Unlike `withPrefix`, which appends to existing prefixes, `resetPrefix` always starts with a clean slate.
+ *
+ * @example Basic Reset
+ *
+ * ```ts
+ * import { ConsoleLogger, withPrefix, resetPrefix } from 'emitnlog/logger';
+ *
+ * const logger = new ConsoleLogger();
+ * const dbLogger = withPrefix(logger, 'DB');
+ * const userDbLogger = withPrefix(dbLogger, 'users'); // Prefix: "DB.users"
+ *
+ * // Reset to a completely new prefix
+ * const apiLogger = resetPrefix(userDbLogger, 'API'); // Prefix: "API" (not "DB.users.API")
+ *
+ * apiLogger.info('API server started');
+ * // Output: "API: API server started"
+ * ```
+ *
+ * @example Switching Context
+ *
+ * ```ts
+ * // Start with a deeply nested logger
+ * const serviceLogger = withPrefix(logger, 'UserService');
+ * const repoLogger = appendPrefix(serviceLogger, 'Repository');
+ * const cacheLogger = appendPrefix(repoLogger, 'Cache'); // Prefix: "UserService.Repository.Cache"
+ *
+ * // Switch to a completely different context
+ * const authLogger = resetPrefix(cacheLogger, 'Auth'); // Prefix: "Auth"
+ * const tokenLogger = appendPrefix(authLogger, 'Token'); // Prefix: "Auth.Token"
+ *
+ * tokenLogger.d`Token validated successfully`;
+ * // Output: "Auth.Token: Token validated successfully"
+ * ```
+ *
+ * @example Custom Configuration
+ *
+ * ```ts
+ * const existingLogger = withPrefix(logger, 'OldPrefix');
+ *
+ * // Reset with custom separators
+ * const newLogger = resetPrefix(existingLogger, 'NewPrefix', { prefixSeparator: '/', messageSeparator: ' >> ' });
+ *
+ * const subLogger = appendPrefix(newLogger, 'SubModule');
+ * subLogger.info('Module initialized');
+ * // Output: "NewPrefix/SubModule >> Module initialized"
+ * ```
+ *
+ * @example Reusing Root Logger
+ *
+ * ```ts
+ * // Multiple loggers sharing the same root but with different prefixes
+ * const dbLogger = withPrefix(logger, 'DB');
+ * const complexDbLogger = appendPrefix(dbLogger, 'Complex'); // Prefix: "DB.Complex"
+ *
+ * // Create parallel hierarchies from the same root
+ * const cacheLogger = resetPrefix(complexDbLogger, 'Cache'); // Uses same root as dbLogger
+ * const metricsLogger = resetPrefix(complexDbLogger, 'Metrics'); // Uses same root as dbLogger
+ *
+ * cacheLogger.info('Cache warmed up'); // Output: "Cache: Cache warmed up"
+ * metricsLogger.info('Metrics collected'); // Output: "Metrics: Metrics collected"
+ * ```
+ *
+ * @param logger The logger to extract the root logger from and apply a new prefix to
+ * @param prefix The new prefix to apply (completely replacing any existing prefix)
+ * @param options Optional configuration for the new prefixed logger
+ * @returns A new logger with the specified prefix, using the root logger from the input
+ */
+export const resetPrefix = <const TPrefix extends string, const TSeparator extends string = '.'>(
   logger: Logger,
-): { readonly currentPrefix: string; readonly basicLogger: Logger } | undefined => {
-  if (
-    prefixSymbol in logger &&
-    typeof logger[prefixSymbol] === 'string' &&
-    logger[prefixSymbol] &&
-    basicLoggerSymbol in logger
-  ) {
-    return { currentPrefix: logger[prefixSymbol], basicLogger: logger[basicLoggerSymbol] as Logger };
-  }
+  prefix: TPrefix,
+  options?: {
+    /**
+     * The separator to use between an existing prefix and the prefix passed to this method. Defaults to '.'.
+     */
+    readonly prefixSeparator?: TSeparator;
 
-  return undefined;
+    /**
+     * The separator to use between the prefix and the log message. Defaults to ': '.
+     */
+    readonly messageSeparator?: string;
+  },
+): WithPrefixResult<Logger, TPrefix, TSeparator> => {
+  const data = inspectPrefixedLogger(logger);
+  if (data) {
+    logger = data.rootLogger;
+  }
+  return withPrefix(logger, prefix, options);
 };
 
-const prefixTemplateString = (
-  prefixLogger: PrefixedLogger<string>,
-  strings: TemplateStringsArray,
-  messageSeparator: string,
-): TemplateStringsArray => {
-  const prefix = prefixLogger[prefixSymbol];
+export const isPrefixedLogger = (logger: Logger | undefined | null): logger is PrefixedLogger =>
+  isNotNullable(logger) && prefixSymbol in logger && typeof logger[prefixSymbol] === 'string' && dataSymbol in logger;
+
+export const inspectPrefixedLogger = (
+  logger: Logger,
+):
+  | {
+      readonly rootLogger: Logger;
+      readonly prefix: string;
+      readonly separator: string;
+      readonly messageSeparator: string;
+    }
+  | undefined =>
+  isPrefixedLogger(logger)
+    ? {
+        rootLogger: logger[dataSymbol]!.rootLogger,
+        prefix: logger[prefixSymbol]!,
+        separator: logger[separatorSymbol]!,
+        messageSeparator: logger[dataSymbol]!.messageSeparator,
+      }
+    : undefined;
+
+const prefixTemplateString = (prefixLogger: PrefixedLogger, strings: TemplateStringsArray): TemplateStringsArray => {
+  const prefix = prefixLogger[prefixSymbol]!;
+  const messageSeparator = prefixLogger[dataSymbol]!.messageSeparator;
   const newStrings = Array.from(strings);
   newStrings[0] = `${prefix}${messageSeparator}${newStrings[0]}`;
   const prefixedStrings = Object.assign(newStrings, { raw: Array.from(strings.raw) });
@@ -251,13 +534,20 @@ const prefixTemplateString = (
   return prefixedStrings as unknown as TemplateStringsArray;
 };
 
-const toMessageProvider =
-  (prefixLogger: PrefixedLogger<string>, message: LogMessage, messageSeparator: string) => () => {
-    const messageString = typeof message === 'function' ? message() : message;
-    return `${prefixLogger[prefixSymbol]}${messageSeparator}${messageString}`;
-  };
+const toMessageProvider = (prefixLogger: PrefixedLogger, message: LogMessage) => () => {
+  const messageString = typeof message === 'function' ? message() : message;
+  const messageSeparator = prefixLogger[dataSymbol]!.messageSeparator;
+  return `${prefixLogger[prefixSymbol]}${messageSeparator}${messageString}`;
+};
 
-type WithPrefixResult<TLogger extends Logger, TNewPrefix extends string> =
-  TLogger extends PrefixedLogger<infer TPrevPrefix>
-    ? PrefixedLogger<`${TPrevPrefix}${TNewPrefix}`>
-    : PrefixedLogger<TNewPrefix>;
+type WithPrefixResult<
+  TLogger extends Logger,
+  TNewPrefix extends string,
+  TSeparator extends string = '.',
+  TFallbackPrefix extends string | undefined = undefined,
+> =
+  TLogger extends PrefixedLogger<infer TPrevPrefix, infer TPrevSeparator>
+    ? PrefixedLogger<`${TPrevPrefix}${TPrevSeparator}${TNewPrefix}`, TPrevSeparator>
+    : TFallbackPrefix extends string
+      ? PrefixedLogger<`${TFallbackPrefix}${TSeparator}${TNewPrefix}`, TSeparator>
+      : PrefixedLogger<TNewPrefix, TSeparator>;


### PR DESCRIPTION
`withPrefix` is not friendly when using with complex code.

The changes include:
- exposes inner properties so clients can choose to create brand new
  prefixedLoggers
- is opinionated: the first code that creates the prefixed logger is the
  one that decides the prefixSeparator, and messageSeparator