### PR TITLE
feat(tracker): redesign 'phase' into 'stage'

### DIFF
--- a/.changeset/soft-shoes-stick.md
+++ b/.changeset/soft-shoes-stick.md
@@ -1,0 +1,5 @@
+---
+'emitnlog': minor
+---
+
+The tracker invocation now expose the 'stage' information as a property

--- a/src/tracker/index.ts
+++ b/src/tracker/index.ts
@@ -2,4 +2,5 @@ export * from './definition.ts';
 export * from './implementation.ts';
 export * from './stack/definition.ts';
 export * from './stack/implementation.ts';
+export * from './stage-invocation.ts';
 export * from './track-methods.ts';

--- a/src/tracker/stage-invocation.ts
+++ b/src/tracker/stage-invocation.ts
@@ -1,0 +1,6 @@
+import type { Invocation, InvocationAtStage } from './definition.ts';
+
+export const isAtStage = <T extends Invocation['stage']['type']>(
+  invocation: Invocation | undefined,
+  stage: T,
+): invocation is InvocationAtStage<T> => invocation?.stage.type === stage;

--- a/tests/tracker/track-methods.test.ts
+++ b/tests/tracker/track-methods.test.ts
@@ -310,13 +310,13 @@ describe('trackMethods', () => {
 
       expect(operationInvocations).toHaveLength(4);
       expect(operationInvocations[0].key.operation).toBe('add');
-      expect(operationInvocations[0].phase).toBe('started');
+      expect(operationInvocations[0].stage.type).toBe('started');
       expect(operationInvocations[1].key.operation).toBe('add');
-      expect(operationInvocations[1].phase).toBe('completed');
+      expect(operationInvocations[1].stage.type).toBe('completed');
       expect(operationInvocations[2].key.operation).toBe('subtract');
-      expect(operationInvocations[2].phase).toBe('started');
+      expect(operationInvocations[2].stage.type).toBe('started');
       expect(operationInvocations[3].key.operation).toBe('subtract');
-      expect(operationInvocations[3].phase).toBe('completed');
+      expect(operationInvocations[3].stage.type).toBe('completed');
     });
   });
 });


### PR DESCRIPTION
Changes the invocation to "contain" a 'stage' instead of being a 'phase'.