### PR TITLE
feat(logger): fromEnv and runtime

### DIFF
--- a/.changeset/cute-boats-cry.md
+++ b/.changeset/cute-boats-cry.md
@@ -1,0 +1,5 @@
+---
+'emitnlog': minor
+---
+
+Add a dynamic version of `fromEnv` that supports both neutral and node

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/m-paternostro/emitnlog/blob/main/LICENSE)
-[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/m-paternostro/emitnlog)](https://github.com/m-paternostro/emitnlog/releases)
 [![NPM](https://img.shields.io/badge/NPM-%23CB3837.svg?logo=npm&logoColor=white)](https://www.npmjs.com/package/emitnlog)
-[![Version](https://img.shields.io/github/package-json/v/m-paternostro/emitnlog)](https://github.com/m-paternostro/emitnlog/blob/main/package.json)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/m-paternostro/emitnlog)](https://github.com/m-paternostro/emitnlog/releases)
 [![CI](https://github.com/m-paternostro/emitnlog/actions/workflows/ci.yaml/badge.svg)](https://github.com/m-paternostro/emitnlog/actions/workflows/ci.yaml)
 [![Coverage](https://m-paternostro.github.io/emitnlog/coverage/coverage-badge.svg)](https://m-paternostro.github.io/emitnlog/coverage/)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/m-paternostro/emitnlog/blob/main/LICENSE)
 
 # Emit n' Log
 
@@ -193,7 +192,7 @@ Configure logging behavior through environment variables for easy deployment-tim
 > **Note:** Supported on Node.js or on runtimes where `process.env` exposes the environment variables.
 
 ```ts
-import { fromEnv } from 'emitnlog/logger';
+import { fromEnv } from 'emitnlog/logger/environment';
 
 // Creates logger based on environment variables
 const logger = fromEnv();
@@ -209,7 +208,7 @@ Configure your logger with these environment variables:
 # Logger type (required)
 EMITNLOG_LOGGER=console                # Use ConsoleLogger
 EMITNLOG_LOGGER=console-error          # Use ConsoleErrorLogger
-EMITNLOG_LOGGER=file:/var/log/app.log  # Use FileLogger with specified path
+EMITNLOG_LOGGER=file:/var/log/app.log  # Use FileLogger with specified path (Node.js only)
 
 # Log level (optional)
 EMITNLOG_LEVEL=debug                   # Set minimum log level
@@ -223,7 +222,8 @@ EMITNLOG_FORMAT=colorful               # Use colored output
 Provide defaults and fallback behavior when environment variables aren't set:
 
 ```ts
-import { fromEnv, ConsoleLogger } from 'emitnlog/logger';
+import { ConsoleLogger } from 'emitnlog/logger';
+import { fromEnv } from 'emitnlog/logger/environment';
 
 // With fallback options
 const logger = fromEnv({
@@ -245,6 +245,22 @@ const logger = fromEnv({
   },
 });
 ```
+
+### Choosing the Right `fromEnv` Import
+
+There are three available `fromEnv` variants, depending on your runtime or preferences:
+
+```ts
+import { fromEnv } from 'emitnlog/logger/environment'; // dynamic resolution (recommended)
+import { fromEnv } from 'emitnlog/logger'; // neutral-only (browser-safe)
+import { fromEnv } from 'emitnlog/logger/node'; // Node-only (file support)
+```
+
+- The first form (`/logger/environment`) uses conditional exports to automatically select the correct logger at runtime: it supports file logging in Node.js, and gracefully disables it in browser-safe builds. This is the recommended option for most users.
+
+- The second form (`/logger`) is always neutral and safe to use in any environment — but does not support file loggers.
+
+- The third form (`/logger/node`) gives you full control of Node-only features like FileLogger, and should only be used when you’re explicitly targeting Node.
 
 #### Example
 
@@ -269,7 +285,7 @@ EMITNLOG_FORMAT=plain
 
 ```ts
 // app.ts - Works in all environments
-import { fromEnv } from 'emitnlog/logger';
+import { fromEnv } from 'emitnlog/logger/environment';
 
 const logger = fromEnv({
   level: 'info', // Reasonable default

--- a/package.json
+++ b/package.json
@@ -47,6 +47,16 @@
         "default": "./dist/node/logger/node/index.cjs"
       }
     },
+    "./logger/environment": {
+      "import": {
+        "node": "./dist/node/logger/environment.js",
+        "default": "./dist/neutral/logger/environment.js"
+      },
+      "require": {
+        "node": "./dist/node/logger/environment.cjs",
+        "default": "./dist/neutral/logger/environment.cjs"
+      }
+    },
     "./notifier": {
       "import": {
         "types": "./dist/neutral/notifier/index.d.ts",

--- a/src/logger/environment-common.ts
+++ b/src/logger/environment-common.ts
@@ -1,0 +1,145 @@
+import { ConsoleErrorLogger } from './console-error-logger.ts';
+import { ConsoleLogger } from './console-logger.ts';
+import type { Logger, LogLevel } from './definition.ts';
+import type { EmitterFormat } from './emitter.ts';
+import { isEmitterFormat } from './emitter.ts';
+import { isLogLevel } from './level-utils.ts';
+import { OFF_LOGGER } from './off-logger.ts';
+
+const ENV_LOGGER = 'EMITNLOG_LOGGER';
+const ENV_LEVEL = 'EMITNLOG_LEVEL';
+const ENV_FORMAT = 'EMITNLOG_FORMAT';
+
+/**
+ * The options for the `fromEnv` function.
+ */
+export type EnvironmentLoggerOptions = {
+  /**
+   * The level to use if the environment variable `EMITNLOG_LEVEL` is not set.
+   */
+  readonly level?: LogLevel;
+
+  /**
+   * The format to use if the environment variable `EMITNLOG_FORMAT` is not set.
+   */
+  readonly format?: EmitterFormat;
+
+  /**
+   * Returns the fallback logger to use if the environment variable `ENV_LOGGER` is not set.
+   *
+   * @param level The level to use set, which is `EMITNLOG_LEVEL`, `options.level`, or undefined.
+   * @param format The format to use, which is `EMITNLOG_FORMAT`, `options.format`, or undefined.
+   * @returns The fallback logger to use or undefined.
+   */
+  readonly fallbackLogger?: (level?: LogLevel, format?: EmitterFormat) => Logger | undefined;
+};
+
+type EnvLogger = 'console' | 'console-error' | `file:${string}`;
+
+const isEnvLogger = (value: unknown): value is EnvLogger =>
+  value === 'console' || value === 'console-error' || (typeof value === 'string' && value.startsWith('file:'));
+
+const isEnvHolder = (value: unknown): value is { readonly env: Record<string, string | undefined> } =>
+  !!value && typeof value === 'object' && 'env' in value && !!value.env && typeof value.env === 'object';
+
+export const toEnv = (): Record<string, string | undefined> | undefined => {
+  // eslint-disable-next-line no-undef
+  if (typeof process !== 'undefined' && isEnvHolder(process)) {
+    // eslint-disable-next-line no-undef
+    return process.env;
+  }
+
+  // This is not working with jest: time for vitest?
+  // const meta = import.meta as unknown as { readonly env: Record<string, string | undefined> };
+  // if (typeof meta !== 'undefined' && isEnvHolder(meta)) {
+  //   return meta.env;
+  // }
+
+  return undefined;
+};
+
+type DecodedEnv = {
+  readonly envLogger?: EnvLogger;
+  readonly envLevel?: LogLevel;
+  readonly envFormat?: EmitterFormat;
+  readonly envFile?: string;
+};
+
+export const decodeEnv = (
+  env: Record<string, string | undefined> | undefined,
+  options?: EnvironmentLoggerOptions,
+): DecodedEnv | undefined => {
+  let envLogger: EnvLogger | undefined;
+  let envLevel: LogLevel | undefined = options?.level;
+  let envFormat: EmitterFormat | undefined = options?.format;
+  let envFile: string | undefined;
+
+  if (env) {
+    const envLoggerValue = env[ENV_LOGGER];
+    if (isEnvLogger(envLoggerValue)) {
+      if (envLoggerValue.startsWith('file:')) {
+        const file = envLoggerValue.slice(5);
+        if (file) {
+          envLogger = envLoggerValue;
+          envFile = file;
+        } else {
+          // eslint-disable-next-line no-undef, no-console
+          console.warn(
+            `The value of the environment variable '${ENV_LOGGER}' must provide a file path: '${envLoggerValue}'.\nConsult the emitnlog documentation for the list of valid loggers.`,
+          );
+        }
+      } else {
+        envLogger = envLoggerValue;
+      }
+    } else if (envLoggerValue) {
+      // eslint-disable-next-line no-undef, no-console
+      console.warn(
+        `The value of the environment variable '${ENV_LOGGER}' is not a valid logger: '${envLoggerValue}'.\nConsult the emitnlog documentation for the list of valid loggers.`,
+      );
+    }
+
+    const envLevelValue = env[ENV_LEVEL];
+    if (isLogLevel(envLevelValue)) {
+      envLevel = envLevelValue;
+    } else if (envLevelValue) {
+      // eslint-disable-next-line no-undef, no-console
+      console.warn(
+        `The value of the environment variable '${ENV_LEVEL}' is not a valid level: '${envLevelValue}'.\nConsult the emitnlog documentation for the list of valid levels.`,
+      );
+    }
+
+    const envFormatValue = env[ENV_FORMAT];
+    if (envFormatValue) {
+      if (isEmitterFormat(envFormatValue)) {
+        envFormat = envFormatValue;
+      } else if (envFormatValue) {
+        // eslint-disable-next-line no-undef, no-console
+        console.warn(
+          `The value of the environment variable '${ENV_FORMAT}' is not a valid format: '${envFormatValue}'.\nConsult the emitnlog documentation for the list of valid formats.`,
+        );
+      }
+    }
+  }
+
+  return envLogger || envLevel || envFormat ? { envLogger, envLevel, envFormat, envFile } : undefined;
+};
+
+export const createLoggerFromEnv = (
+  decodedEnv: DecodedEnv | undefined,
+  options: EnvironmentLoggerOptions | undefined,
+): Logger => {
+  if (decodedEnv) {
+    if (decodedEnv.envLogger === 'console') {
+      return new ConsoleLogger(decodedEnv.envLevel, decodedEnv.envFormat);
+    }
+
+    if (decodedEnv.envLogger === 'console-error') {
+      return new ConsoleErrorLogger(decodedEnv.envLevel, decodedEnv.envFormat);
+    }
+
+    // eslint-disable-next-line no-undef, no-console
+    console.warn(`The file logger is only supported in Node.js.`);
+  }
+
+  return options?.fallbackLogger?.(decodedEnv?.envLevel, decodedEnv?.envFormat) ?? OFF_LOGGER;
+};

--- a/src/logger/environment-logger.ts
+++ b/src/logger/environment-logger.ts
@@ -36,6 +36,55 @@ import { createLoggerFromEnv, decodeEnv, toEnv } from './environment-common.ts';
  *
  * If a environment variable is not set, the associated value in `options` is used.
  *
+ * @example
+ *
+ * ```typescript
+ * import { fromEnv } from 'emitnlog/logger/environment';
+ *
+ * // Basic usage - uses environment variables if set, otherwise returns OFF_LOGGER
+ * const logger = fromEnv();
+ * ```
+ *
+ * @example
+ *
+ * ```typescript
+ * import { fromEnv } from 'emitnlog/logger/environment';
+ *
+ * // With fallback options when environment variables are not set
+ * const logger = fromEnv({
+ *   // Used if EMITNLOG_LEVEL is not set
+ *   level: 'debug',
+ *
+ *   // Used if EMITNLOG_FORMAT is not set
+ *   format: 'plain',
+ * });
+ * ```
+ *
+ * @example
+ *
+ * ```typescript
+ * import { fromEnv } from 'emitnlog/logger/environment';
+ *
+ * // With a custom fallback logger
+ * const logger = fromEnv({
+ *   // Used if EMITNLOG_LOGGER is not set
+ *   fallbackLogger: (level, format) => new CustomLogger(level, format),
+ * });
+ * ```
+ *
+ * @example
+ *
+ * ```typescript
+ * import { fromEnv } from 'emitnlog/logger/environment';
+ *
+ * // Using console logger with info level and colorful format
+ * process.env.EMITNLOG_LOGGER = 'console';
+ * process.env.EMITNLOG_LEVEL = 'info';
+ * process.env.EMITNLOG_FORMAT = 'colorful';
+ * const logger = fromEnv();
+ * logger.info('Hello, world!'); // Will output with colors to console
+ * ```
+ *
  * @param options The options to use.
  * @returns The logger to use.
  */

--- a/src/logger/node/environment-logger.ts
+++ b/src/logger/node/environment-logger.ts
@@ -37,6 +37,55 @@ import { FileLogger } from './file-logger.ts';
  *
  * If a environment variable is not set, the associated value in `options` is used.
  *
+ * @example
+ *
+ * ```typescript
+ * import { fromEnv } from 'emitnlog/logger/environment';
+ *
+ * // Basic usage - uses environment variables if set, otherwise returns OFF_LOGGER
+ * const logger = fromEnv();
+ * ```
+ *
+ * @example
+ *
+ * ```typescript
+ * import { fromEnv } from 'emitnlog/logger/environment';
+ *
+ * // With fallback options when environment variables are not set
+ * const logger = fromEnv({
+ *   // Used if EMITNLOG_LEVEL is not set
+ *   level: 'debug',
+ *
+ *   // Used if EMITNLOG_FORMAT is not set
+ *   format: 'plain',
+ * });
+ * ```
+ *
+ * @example
+ *
+ * ```typescript
+ * import { fromEnv } from 'emitnlog/logger/environment';
+ *
+ * // With a custom fallback logger
+ * const logger = fromEnv({
+ *   // Used if EMITNLOG_LOGGER is not set
+ *   fallbackLogger: (level, format) => new CustomLogger(level, format),
+ * });
+ * ```
+ *
+ * @example
+ *
+ * ```typescript
+ * import { fromEnv } from 'emitnlog/logger/node/environment';
+ *
+ * // Using console logger with info level and colorful format
+ * process.env.EMITNLOG_LOGGER = 'console';
+ * process.env.EMITNLOG_LEVEL = 'info';
+ * process.env.EMITNLOG_FORMAT = 'colorful';
+ * const logger = fromEnv();
+ * logger.info('Hello, world!'); // Will output with colors to console
+ * ```
+ *
  * @param options The options to use.
  * @returns The logger to use.
  */

--- a/src/logger/node/environment-logger.ts
+++ b/src/logger/node/environment-logger.ts
@@ -1,6 +1,7 @@
-import type { Logger } from './definition.ts';
-import type { EnvironmentLoggerOptions } from './environment-common.ts';
-import { createLoggerFromEnv, decodeEnv, toEnv } from './environment-common.ts';
+import type { Logger } from '../definition.ts';
+import type { EnvironmentLoggerOptions } from '../environment-common.ts';
+import { createLoggerFromEnv, decodeEnv, toEnv } from '../environment-common.ts';
+import { FileLogger } from './file-logger.ts';
 
 /**
  * Returns the logger to use based on the environment variables.
@@ -42,5 +43,7 @@ import { createLoggerFromEnv, decodeEnv, toEnv } from './environment-common.ts';
 export const fromEnv = (options?: EnvironmentLoggerOptions): Logger => {
   const env = toEnv();
   const decodedEnv = decodeEnv(env, options);
-  return createLoggerFromEnv(decodedEnv, options);
+  return decodedEnv?.envFile
+    ? new FileLogger(decodedEnv.envFile, decodedEnv.envLevel, decodedEnv.envFormat)
+    : createLoggerFromEnv(decodedEnv, options);
 };

--- a/src/logger/node/index.ts
+++ b/src/logger/node/index.ts
@@ -1,1 +1,2 @@
+export * from './environment-logger.ts';
 export * from './file-logger.ts';

--- a/tests-smoke/cjs/flat.test.js
+++ b/tests-smoke/cjs/flat.test.js
@@ -3,6 +3,19 @@ const emitnlog = require('emitnlog');
 describe('CJS Flat imports', () => {
   test('Logger exports are available', () => {
     expect(typeof emitnlog.ConsoleLogger).toBe('function');
+    expect(typeof emitnlog.fromEnv).toBe('function');
+
+    process.env.EMITNLOG_LOGGER = 'file:/tmp/log.txt';
+    {
+      const logger = emitnlog.fromEnv();
+      expect(logger).toBe(emitnlog.OFF_LOGGER);
+    }
+    process.env.EMITNLOG_LOGGER = 'console';
+    {
+      const logger = emitnlog.fromEnv();
+      expect(logger).toBeDefined();
+      expect(logger.constructor.name).toBe('ConsoleLogger');
+    }
   });
 
   test('Notifier exports are available', () => {
@@ -17,11 +30,5 @@ describe('CJS Flat imports', () => {
   test('Utils exports are available', () => {
     expect(typeof emitnlog.createDeferredValue).toBe('function');
     expect(typeof emitnlog.delay).toBe('function');
-  });
-
-  test('Can create and use a logger', () => {
-    const logger = new emitnlog.ConsoleLogger();
-    expect(logger).toBeDefined();
-    expect(typeof logger.log).toBe('function');
   });
 });

--- a/tests-smoke/cjs/named.test.js
+++ b/tests-smoke/cjs/named.test.js
@@ -1,37 +1,54 @@
-const { ConsoleLogger } = require('emitnlog/logger');
+const { ConsoleLogger, fromEnv: fromEnvLogger, OFF_LOGGER } = require('emitnlog/logger');
+const { fromEnv } = require('emitnlog/logger/environment');
 const { createEventNotifier } = require('emitnlog/notifier');
 const { createInvocationTracker } = require('emitnlog/tracker');
 const { createDeferredValue } = require('emitnlog/utils');
 
 describe('CJS Named imports', () => {
   test('Logger import works', () => {
-    const logger = new ConsoleLogger();
-    expect(logger).toBeDefined();
-    expect(typeof logger.log).toBe('function');
+    expect(typeof ConsoleLogger).toBe('function');
+    expect(typeof fromEnvLogger).toBe('function');
+
+    process.env.EMITNLOG_LOGGER = 'file:/tmp/log.txt';
+    {
+      const logger = fromEnvLogger();
+      expect(logger).toBe(OFF_LOGGER);
+    }
+    process.env.EMITNLOG_LOGGER = 'console';
+    {
+      const logger = fromEnvLogger();
+      expect(logger).toBeDefined();
+      expect(logger.constructor.name).toBe('ConsoleLogger');
+    }
+  });
+
+  test('Logger environment import works', () => {
+    expect(typeof fromEnv).toBe('function');
+
+    // The smoke tests run in node so this must work
+    process.env.EMITNLOG_LOGGER = 'file:/tmp/log.txt';
+    {
+      const logger = fromEnv();
+      expect(logger).toBeDefined();
+      expect(logger.constructor.name).toBe('FileLogger');
+    }
+    process.env.EMITNLOG_LOGGER = 'console';
+    {
+      const logger = fromEnv();
+      expect(logger).toBeDefined();
+      expect(logger.constructor.name).toBe('ConsoleLogger');
+    }
   });
 
   test('Notifier import works', () => {
-    const notifier = createEventNotifier();
-    expect(notifier).toBeDefined();
-    expect(typeof notifier.onEvent).toBe('function');
-    expect(typeof notifier.notify).toBe('function');
+    expect(typeof createEventNotifier).toBe('function');
   });
 
   test('Tracker import works', () => {
-    const tracker = createInvocationTracker();
-    expect(tracker).toBeDefined();
-    expect(typeof tracker.track).toBe('function');
-    expect(typeof tracker.onInvoked).toBe('function');
-    expect(typeof tracker.onStarted).toBe('function');
-    expect(typeof tracker.onCompleted).toBe('function');
-    expect(typeof tracker.onErrored).toBe('function');
+    expect(typeof createInvocationTracker).toBe('function');
   });
 
   test('Utils import works', () => {
-    const deferred = createDeferredValue();
-    expect(deferred).toBeDefined();
-    expect(typeof deferred.promise).toBe('object');
-    expect(typeof deferred.resolve).toBe('function');
-    expect(typeof deferred.reject).toBe('function');
+    expect(typeof createDeferredValue).toBe('function');
   });
 });

--- a/tests-smoke/esm/flat.test.js
+++ b/tests-smoke/esm/flat.test.js
@@ -3,28 +3,31 @@ import { expect, test, describe } from '@jest/globals';
 
 describe('ESM Flat imports', () => {
   test('Logger exports are available', () => {
-    expect(emitnlog.ConsoleLogger).toBeDefined();
     expect(typeof emitnlog.ConsoleLogger).toBe('function');
+    expect(typeof emitnlog.fromEnv).toBe('function');
+
+    process.env.EMITNLOG_LOGGER = 'file:/tmp/log.txt';
+    {
+      const logger = emitnlog.fromEnv();
+      expect(logger).toBe(emitnlog.OFF_LOGGER);
+    }
+    process.env.EMITNLOG_LOGGER = 'console';
+    {
+      const logger = emitnlog.fromEnv();
+      expect(logger).toBeDefined();
+      expect(logger.constructor.name).toBe('ConsoleLogger');
+    }
   });
 
   test('Notifier exports are available', () => {
-    expect(emitnlog.createEventNotifier).toBeDefined();
     expect(typeof emitnlog.createEventNotifier).toBe('function');
   });
 
   test('Tracker exports are available', () => {
-    expect(emitnlog.createInvocationTracker).toBeDefined();
     expect(typeof emitnlog.createInvocationTracker).toBe('function');
   });
 
   test('Utils exports are available', () => {
-    expect(emitnlog.createDeferredValue).toBeDefined();
     expect(typeof emitnlog.createDeferredValue).toBe('function');
-  });
-
-  test('Can create and use a logger', () => {
-    const logger = new emitnlog.ConsoleLogger();
-    expect(logger).toBeDefined();
-    expect(typeof logger.log).toBe('function');
   });
 });

--- a/tests-smoke/esm/named.test.js
+++ b/tests-smoke/esm/named.test.js
@@ -1,4 +1,5 @@
-import { ConsoleLogger } from 'emitnlog/logger';
+import { ConsoleLogger, fromEnv as fromEnvLogger, OFF_LOGGER } from 'emitnlog/logger';
+import { fromEnv } from 'emitnlog/logger/environment';
 import { createEventNotifier } from 'emitnlog/notifier';
 import { createInvocationTracker } from 'emitnlog/tracker';
 import { createDeferredValue } from 'emitnlog/utils';
@@ -6,31 +7,49 @@ import { expect, test, describe } from '@jest/globals';
 
 describe('ESM Named imports', () => {
   test('Logger import works', () => {
-    const logger = new ConsoleLogger();
-    expect(logger).toBeDefined();
-    expect(typeof logger.log).toBe('function');
+    expect(typeof ConsoleLogger).toBe('function');
+    expect(typeof fromEnvLogger).toBe('function');
+
+    process.env.EMITNLOG_LOGGER = 'file:/tmp/log.txt';
+    {
+      const logger = fromEnvLogger();
+      expect(logger).toBe(OFF_LOGGER);
+    }
+    process.env.EMITNLOG_LOGGER = 'console';
+    {
+      const logger = fromEnvLogger();
+      expect(logger).toBeDefined();
+      expect(logger.constructor.name).toBe('ConsoleLogger');
+    }
+  });
+
+  test('Logger environment import works', () => {
+    expect(typeof fromEnv).toBe('function');
+
+    // The smoke tests run in node so this must work
+    process.env.EMITNLOG_LOGGER = 'file:/tmp/log.txt';
+    {
+      const logger = fromEnv();
+      expect(logger).toBeDefined();
+      expect(logger.constructor.name).toBe('FileLogger');
+    }
+    process.env.EMITNLOG_LOGGER = 'console';
+    {
+      const logger = fromEnv();
+      expect(logger).toBeDefined();
+      expect(logger.constructor.name).toBe('ConsoleLogger');
+    }
   });
 
   test('Notifier import works', () => {
-    const notifier = createEventNotifier();
-    expect(notifier).toBeDefined();
-    expect(typeof notifier.onEvent).toBe('function');
-    expect(typeof notifier.notify).toBe('function');
+    expect(typeof createEventNotifier).toBe('function');
   });
 
   test('Tracker import works', () => {
-    const tracker = createInvocationTracker();
-    expect(tracker).toBeDefined();
-    expect(typeof tracker.track).toBe('function');
-    expect(typeof tracker.onInvoked).toBe('function');
-    expect(typeof tracker.onStarted).toBe('function');
+    expect(typeof createInvocationTracker).toBe('function');
   });
 
   test('Utils import works', () => {
-    const deferred = createDeferredValue();
-    expect(deferred).toBeDefined();
-    expect(typeof deferred.promise).toBe('object');
-    expect(typeof deferred.resolve).toBe('function');
-    expect(typeof deferred.reject).toBe('function');
+    expect(typeof createDeferredValue).toBe('function');
   });
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig([
     entry: {
       index: 'src/index.ts',
       'logger/index': 'src/logger/index.ts',
+      'logger/environment': 'src/logger/environment-logger.ts',
       'notifier/index': 'src/notifier/index.ts',
       'tracker/index': 'src/tracker/index.ts',
       'utils/index': 'src/utils/index.ts',
@@ -22,7 +23,11 @@ export default defineConfig([
   },
   {
     outDir: 'dist/node',
-    entry: { 'logger/node/index': 'src/logger/node/index.ts', 'tracker/node/index': 'src/tracker/node/index.ts' },
+    entry: {
+      'logger/node/index': 'src/logger/node/index.ts',
+      'logger/environment': 'src/logger/node/environment-logger.ts',
+      'tracker/node/index': 'src/tracker/node/index.ts',
+    },
     format: ['esm', 'cjs'],
     platform: 'node',
     target: 'node20',


### PR DESCRIPTION
Ensure that `fromEnv` works correctly on neutral and node runtimes and provide a dynamic loading option.