### PR TITLE
chore(utils): sync utilities docs with code; fix poll JSDoc

### DIFF
--- a/.changeset/four-jars-stand.md
+++ b/.changeset/four-jars-stand.md
@@ -1,0 +1,5 @@
+---
+'emitnlog': patch
+---
+
+Utils small improvements: sync utilities docs with code; improve JSDoc

--- a/.changeset/swift-nights-exist.md
+++ b/.changeset/swift-nights-exist.md
@@ -2,4 +2,4 @@
 'emitnlog': patch
 ---
 
-Clarify invocation index, export promise option types, and fix docs
+Tracker small improvements: clarify invocation index, export promise option types, and fix docs

--- a/src/utils/async/poll.ts
+++ b/src/utils/async/poll.ts
@@ -62,10 +62,11 @@ export type PollingOptions<T, V> = {
  * import { startPolling } from 'emitnlog/utils';
  *
  * // Poll every 5 seconds until manually stopped
- * const closeable = startPolling(() => fetchLatestData(), 5_000);
+ * const { wait, close } = startPolling(() => fetchLatestData(), 5_000);
  *
  * // Stop polling after 30 seconds
- * await delay(30_000).then(close);
+ * await delay(30_000);
+ * await close();
  *
  * // Get the final result
  * const finalData = await wait;

--- a/src/utils/async/types.ts
+++ b/src/utils/async/types.ts
@@ -1,4 +1,4 @@
 /**
- * A type representing the return value of the `setTimeout` and `setInterval` functions.
+ * A type representing the return value of timer functions like `setTimeout`.
  */
 export type Timeout = ReturnType<typeof setTimeout>;

--- a/src/utils/async/with-timeout.ts
+++ b/src/utils/async/with-timeout.ts
@@ -6,7 +6,8 @@ import { delay } from './delay.ts';
  *
  * Note: The original promise continues to run in the background even if the timeout occurs. If caching promises,
  * consider caching the original promise instead of the timed one, since it may resolve successfully on a subsequent
- * access.
+ * access. If the original promise is not consumed elsewhere and later rejects, it may trigger an unhandled rejection;
+ * consider attaching a `.catch()` to the original or otherwise observing its outcome.
  *
  * @example
  *


### PR DESCRIPTION
- Updated `stringify` date/output options; corrected debounce options,
- Documented polling options (invokeImmediately, retryLimit, timeoutValue, logger),
- Added `terminalFormatter` and singleton sections,
- Clarified `withTimeout` caveat; tighten Timeout JSDoc