### PR TITLE
feat(logger,docs): standardize docs and adopt better severity scale

### DIFF
--- a/docs/logger.md
+++ b/docs/logger.md
@@ -37,10 +37,10 @@ emergency - System is unusable
 Defines the format used to emit a log entry.
 
 ```
-plain            - One plain text line per entry, no styling.
-colorful         - ANSI-colored line, ideal for dev terminals.
-json             - One structured JSON line per entry.
-unformatted-json - Compact JSON line, raw and delimiter-safe.
+plain         - One plain text line per entry, no styling.
+colorful      - ANSI-colored line, ideal for dev terminals.
+json-compact  - Compact JSON line, raw and delimiter-safe.
+json-pretty   - Pretty-printed JSON with indentation.
 ```
 
 ## Template Logging
@@ -148,7 +148,7 @@ All loggers implement the same interface, making them interchangeable. Use facto
 
 ### Console Log Logger
 
-Logs to console (stdout) with intelligent routing and color formatting.
+Logs everything to stdout (`console.log`). Uses color formatting by default.
 
 ```ts
 import { createConsoleLogLogger } from 'emitnlog/logger';
@@ -240,7 +240,7 @@ Configure logging behavior through environment variables for easy deployment-tim
 > **Note:** Supported on Node.js or on runtimes where `process.env` exposes the environment variables.
 
 ```ts
-import { fromEnv } from 'emitnlog/logger/environment';
+import { fromEnv } from 'emitnlog/logger';
 
 // Creates logger based on environment variables
 const logger = fromEnv();
@@ -263,7 +263,7 @@ EMITNLOG_LOGGER=console-level
 # Use FileLogger with specified path (Node.js only)
 EMITNLOG_LOGGER=file:/var/log/app.log
 # Use FileLogger with the date prefixed to the specified path (Node.js only)
-EMITNLOG_LOGGER=file:date/var/log/app.log
+EMITNLOG_LOGGER=file:date:/var/log/app.log
 
 # Log level (optional)
 EMITNLOG_LEVEL=debug                   # Set minimum log level
@@ -277,13 +277,12 @@ EMITNLOG_FORMAT=colorful               # Use colored output
 Provide defaults and fallback behavior when environment variables aren't set:
 
 ```ts
-import { createConsoleLogLogger } from 'emitnlog/logger';
-import { fromEnv } from 'emitnlog/logger/environment';
+import { createConsoleLogLogger, fromEnv } from 'emitnlog/logger';
 
 // With fallback options
 const logger = fromEnv({
   level: 'info', // Default level if EMITNLOG_LEVEL not set
-  format: 'unformatted-json', // Default format if EMITNLOG_FORMAT not set
+  format: 'json-compact', // Default format if EMITNLOG_FORMAT not set
   fallbackLogger: () => createConsoleLogLogger(),
 });
 
@@ -307,14 +306,14 @@ A typical application setup that adapts to different environments:
 
 ```bash
 # Development (.env.development)
-EMITNLOG_LOGGER=console
+EMITNLOG_LOGGER=console-log
 EMITNLOG_LEVEL=debug
 EMITNLOG_FORMAT=colorful
 
 # Production (.env.production)
 EMITNLOG_LOGGER=file:/var/log/app.log
 EMITNLOG_LEVEL=warning
-EMITNLOG_FORMAT=json
+EMITNLOG_FORMAT=json-compact
 
 # Testing (.env.test)
 EMITNLOG_LOGGER=console-error
@@ -324,7 +323,7 @@ EMITNLOG_FORMAT=plain
 
 ```ts
 // app.ts - Works in all environments
-import { fromEnv } from 'emitnlog/logger/environment';
+import { fromEnv } from 'emitnlog/logger';
 
 const logger = fromEnv({
   level: 'info', // Reasonable default

--- a/src/logger/environment/environment-logger.ts
+++ b/src/logger/environment/environment-logger.ts
@@ -39,7 +39,7 @@ import { createLoggerFromEnv, decodeEnv, toEnv } from './shared.ts';
  * @example
  *
  * ```typescript
- * import { fromEnv } from 'emitnlog/logger/environment';
+ * import { fromEnv } from 'emitnlog/logger';
  *
  * // Basic usage - uses environment variables if set, otherwise returns OFF_LOGGER
  * const logger = fromEnv();
@@ -48,7 +48,7 @@ import { createLoggerFromEnv, decodeEnv, toEnv } from './shared.ts';
  * @example
  *
  * ```typescript
- * import { fromEnv } from 'emitnlog/logger/environment';
+ * import { fromEnv } from 'emitnlog/logger';
  *
  * // With fallback options when environment variables are not set
  * const logger = fromEnv({
@@ -63,7 +63,7 @@ import { createLoggerFromEnv, decodeEnv, toEnv } from './shared.ts';
  * @example
  *
  * ```typescript
- * import { fromEnv } from 'emitnlog/logger/environment';
+ * import { fromEnv } from 'emitnlog/logger';
  *
  * // With a custom fallback logger
  * const logger = fromEnv({
@@ -75,10 +75,10 @@ import { createLoggerFromEnv, decodeEnv, toEnv } from './shared.ts';
  * @example
  *
  * ```typescript
- * import { fromEnv } from 'emitnlog/logger/environment';
+ * import { fromEnv } from 'emitnlog/logger';
  *
  * // Using console logger with info level and colorful format
- * process.env.EMITNLOG_LOGGER = 'console';
+ * process.env.EMITNLOG_LOGGER = 'console-log';
  * process.env.EMITNLOG_LEVEL = 'info';
  * process.env.EMITNLOG_FORMAT = 'colorful';
  * const logger = fromEnv();

--- a/src/logger/implementation/level-utils.ts
+++ b/src/logger/implementation/level-utils.ts
@@ -31,30 +31,26 @@ export const isLogLevel = (value: unknown): value is LogLevel => {
 /**
  * Converts a LogLevel to its corresponding numeric severity value for comparison operations.
  *
- * This function maps each log level to a numeric value according to its severity, with lower numbers representing
- * higher severity (more important) levels:
+ * This function maps each log level to a numeric value according to its severity, with higher numbers representing
+ * higher severity (more important) levels. In other words, the return of this function follows this rule: `trace` <
+ * `debug` < `info` < `notice` < `warning` < `error` < `critical` < `alert` < `emergency`.
  *
- * - Emergency: 0 (highest severity)
- * - Alert: 1
- * - Critical: 2
- * - Error: 3
- * - Warning: 4
- * - Notice: 5
- * - Info: 6
- * - Debug: 7
- * - Trace: 8 (lowest severity)
+ * Clients should not use the numeric values directly as they may change in the future, but rather use this function to
+ * compare levels.
  *
  * @example
  *
  * ```ts
- * import { toLevelWeight } from 'emitnlog/logger';
+ * import { toLevelSeverity } from 'emitnlog/logger';
  *
- * const errorWeight = toLevelSeverity('error'); // Returns 3
- * const debugWeight = toLevelSeverity('debug'); // Returns 7
+ * const errorSeverity = toLevelSeverity('error');
+ * const debugSeverity = toLevelSeverity('debug');
+ * console.log(`Error is higher: ${errorSeverity > debugSeverity}`); // Outputs: Error is higher: true
  *
  * // Compare severity levels
- * if (toLevelWeight('error') < toLevelWeight('debug')) {
- *   // This condition is true (3 < 7), meaning 'error' is more severe than 'debug'
+ * const level: LogLevel = ...
+ * if (toLevelSeverity('level') > toLevelSeverity('debug')) {
+ *   // Indicates 'level' is more severe than 'debug'
  * }
  * ```
  *
@@ -65,42 +61,47 @@ export const isLogLevel = (value: unknown): value is LogLevel => {
 export const toLevelSeverity = (level: LogLevel): number => {
   switch (level) {
     case 'trace':
-      return 8;
+      return 2;
 
     case 'debug':
-      return 7;
+      return 4;
 
     case 'info':
       return 6;
 
     case 'notice':
-      return 5;
+      return 8;
 
     case 'warning':
-      return 4;
+      return 10;
 
     case 'error':
-      return 3;
+      return 12;
 
     case 'critical':
-      return 2;
+      return 14;
 
     case 'alert':
-      return 1;
+      return 16;
 
     case 'emergency':
-      return 0;
+      return 18;
 
     default:
       exhaustiveCheck(level);
-      return 20;
+      return 0;
   }
 };
 
 /**
+ * The highest severity log level.
+ */
+export const HIGHEST_SEVERITY_LOG_LEVEL: LogLevel = 'emergency';
+
+/**
  * The lowest severity log level.
  */
-export const LOWEST_SEVERITY_LOG_LEVEL: LogLevel = 'emergency';
+export const LOWEST_SEVERITY_LOG_LEVEL: LogLevel = 'trace';
 
 /**
  * Determines whether a log entry should be emitted based on the configured logger level and the entry's level.
@@ -111,8 +112,7 @@ export const LOWEST_SEVERITY_LOG_LEVEL: LogLevel = 'emergency';
  * - Otherwise, entries are emitted when their level's severity is equal to or greater than the logger's level
  *
  * For example, if the logger's level is set to 'warning', entries with levels 'warning', 'error', 'critical', 'alert',
- * and 'emergency' will be emitted, while entries with levels 'notice', 'info', 'debug', and 'trace' will be filtered
- * out.
+ * and 'emergency' are emitted, while entries with levels 'notice', 'info', 'debug', and 'trace' are filtered out.
  *
  * @example
  *
@@ -138,7 +138,7 @@ export const shouldEmitEntry = (loggerLevel: Logger | LogLevel | 'off', entryLev
     return false;
   }
 
-  return toLevelSeverity(loggerLevel) >= toLevelSeverity(entryLevel);
+  return toLevelSeverity(entryLevel) >= toLevelSeverity(loggerLevel);
 };
 
 /**

--- a/src/logger/node/environment-logger.ts
+++ b/src/logger/node/environment-logger.ts
@@ -42,7 +42,7 @@ import { createFileLogger } from './factory.ts';
  * @example
  *
  * ```typescript
- * import { fromEnv } from 'emitnlog/logger/environment';
+ * import { fromEnv } from 'emitnlog/logger';
  *
  * // Basic usage - uses environment variables if set, otherwise returns OFF_LOGGER
  * const logger = fromEnv();
@@ -51,7 +51,7 @@ import { createFileLogger } from './factory.ts';
  * @example
  *
  * ```typescript
- * import { fromEnv } from 'emitnlog/logger/environment';
+ * import { fromEnv } from 'emitnlog/logger';
  *
  * // With fallback options when environment variables are not set
  * const logger = fromEnv({
@@ -66,7 +66,7 @@ import { createFileLogger } from './factory.ts';
  * @example
  *
  * ```typescript
- * import { fromEnv } from 'emitnlog/logger/environment';
+ * import { fromEnv } from 'emitnlog/logger';
  *
  * // With a custom fallback logger
  * const logger = fromEnv({
@@ -78,10 +78,10 @@ import { createFileLogger } from './factory.ts';
  * @example
  *
  * ```typescript
- * import { fromEnv } from 'emitnlog/logger/node/environment';
+ * import { fromEnv } from 'emitnlog/logger';
  *
  * // Using console logger with info level and colorful format
- * process.env.EMITNLOG_LOGGER = 'console';
+ * process.env.EMITNLOG_LOGGER = 'console-log';
  * process.env.EMITNLOG_LEVEL = 'info';
  * process.env.EMITNLOG_FORMAT = 'colorful';
  * const logger = fromEnv();

--- a/src/logger/off-logger.ts
+++ b/src/logger/off-logger.ts
@@ -59,7 +59,7 @@ export const OFF_LOGGER: Logger = Object.freeze({
  *
  * ```ts
  * import type { Logger } from 'emitnlog/logger';
- * import { asNonNullableLogger, withPrefix } from 'emitnlog/logger';
+ * import { withLogger, withPrefix } from 'emitnlog/logger';
  *
  * const calculate = (logger?: Logger) => {
  *   const calculateLogger = withPrefix(withLogger(logger), 'calculate');

--- a/src/logger/prefixed-logger.ts
+++ b/src/logger/prefixed-logger.ts
@@ -136,12 +136,12 @@ export interface PrefixedLogger<TPrefix extends string = string, TSeparator exte
  * @example Level Filtering
  *
  * ```ts
- * import { withPrefix } from 'emitnlog/logger';
+ * import { createConsoleLogLogger, withPrefix } from 'emitnlog/logger';
  *
- * const dbLogger = withPrefix(logger, 'DB');
+ * // Underlying logger controls filtering
+ * const base = createConsoleLogLogger('warning');
+ * const dbLogger = withPrefix(base, 'DB');
  *
- * // Level filtering works the same as the underlying logger
- * dbLogger.level = 'warning';
  * dbLogger.d`This debug message won't be logged`;
  * dbLogger.w`This warning will be logged`;
  * // Output: "DB: This warning will be logged"

--- a/src/logger/tee-logger.ts
+++ b/src/logger/tee-logger.ts
@@ -9,14 +9,11 @@ import { OFF_LOGGER } from './off-logger.ts';
  * The returned logger (a "tee") behaves like a standard logger but duplicates every log operation to each of the
  * underlying loggers.
  *
- * ### Log level synchronization
+ * ### Log level behavior
  *
- * - When the tee logger is created, its `level` is synchronized with the first logger.
- * - When the tee logger's `level` is updated, it updates all underlying loggers.
- * - However, the tee does **not actively keep levels in sync** after that point.
- *
- * Clients should avoid changing the log level on the individual loggers after teeing, as this may lead to inconsistent
- * filtering behavior across outputs.
+ * The tee's `level` is computed from the underlying loggers to be the most permissive among them. It does not expose a
+ * setter and does not attempt to keep child levels in sync. Changing the level of individual child loggers after
+ * composing may lead to different filtering per destination, which is expected.
  *
  * @example
  *

--- a/src/logger/tee-logger.ts
+++ b/src/logger/tee-logger.ts
@@ -1,6 +1,6 @@
 import type { Logger, LogLevel, LogMessage, LogTemplateStringsArray } from './definition.ts';
 import { asSingleFinalizer, type ForgeFinalizer, type MergeFinalizer } from './implementation/finalizer.ts';
-import { LOWEST_SEVERITY_LOG_LEVEL, toLevelSeverity } from './implementation/level-utils.ts';
+import { HIGHEST_SEVERITY_LOG_LEVEL, toLevelSeverity } from './implementation/level-utils.ts';
 import { OFF_LOGGER } from './off-logger.ts';
 
 /**
@@ -11,7 +11,7 @@ import { OFF_LOGGER } from './off-logger.ts';
  *
  * ### Log level behavior
  *
- * The tee's `level` is computed from the underlying loggers to be the most permissive among them. It does not expose a
+ * The tee's `level` is computed from the underlying loggers to be the less severe among them. It does not expose a
  * setter and does not attempt to keep child levels in sync. Changing the level of individual child loggers after
  * composing may lead to different filtering per destination, which is expected.
  *
@@ -52,9 +52,9 @@ export const tee = <T extends readonly Logger[]>(...loggers: T): TeeLogger<T> =>
         return logger.level;
       }
 
-      // Return the most permissive level (i.e., the highest severity) among all loggers
-      return toLevelSeverity(acc) > toLevelSeverity(logger.level) ? acc : logger.level;
-    }, LOWEST_SEVERITY_LOG_LEVEL);
+      // Return the lowest level among all loggers
+      return toLevelSeverity(acc) <= toLevelSeverity(logger.level) ? acc : logger.level;
+    }, HIGHEST_SEVERITY_LOG_LEVEL);
 
     return level;
   };


### PR DESCRIPTION
- Docs: align format names, imports, and examples
- Logger: adopt “higher number = more severe” mapping
- JSDoc: clarify examples and imports
- Tee: compute permissive threshold correctly under new scale