### PR TITLE
fix(closable): update return types for closeAll and asClosable functions

### DIFF
--- a/.changeset/strong-pens-like.md
+++ b/.changeset/strong-pens-like.md
@@ -1,0 +1,5 @@
+---
+'emitnlog': patch
+---
+
+Improve the return types of the `closeAll` and `asClosable` functions to better reflect whether the closables are synchronous or asynchronous.


### PR DESCRIPTION
Improves the return types of the `closeAll` and `asClosable` functions to better reflect whether the closables are synchronous or asynchronous, enhancing the type inference for users.